### PR TITLE
DR-1069 Prevent form to be submitted more than once

### DIFF
--- a/src/wwwroot/controllers/ConfirmationCtrl.js
+++ b/src/wwwroot/controllers/ConfirmationCtrl.js
@@ -109,7 +109,7 @@
       }
       var pass = form.pass.$modelValue || null;
       var checkTerms = form.checkTerms ? $rootScope.getTermsAndConditionsVersion() : null;
-      signup.activateUser(apiKey, form.domain.$modelValue, userName, pass, $translate.use(), form.industry.$modelValue.code, form.phoneNumber.$modelValue, form.country.$modelValue.code, checkTerms)
+      return signup.activateUser(apiKey, form.domain.$modelValue, userName, pass, $translate.use(), form.industry.$modelValue.code, form.phoneNumber.$modelValue, form.country.$modelValue.code, checkTerms)
         .then(function (result) {
           $rootScope.isNewUser = true;
           var credentials = {
@@ -117,7 +117,7 @@
             password: form.pass.$modelValue
           };
 
-          auth.login(credentials).then(function (result) {
+          return auth.login(credentials).then(function (result) {
             if (result.authenticated) {
               $location.path('/');
             }

--- a/src/wwwroot/directives/debounced-ng-click.js
+++ b/src/wwwroot/directives/debounced-ng-click.js
@@ -1,0 +1,31 @@
+(function () {
+    'use strict';
+
+    angular
+      .module('dopplerRelay')
+      .directive('debouncedNgClick', debouncedNgClick);
+
+    debouncedNgClick.$inject = [
+    ];
+
+    function debouncedNgClick() {
+        var directive = {
+            restrict: 'A',
+            link: link,
+            scope: {
+                debouncedNgClick: '&'
+            }
+        };
+
+        return directive;
+
+        function link(scope, element, attrs) {
+            element.on('click', function () {
+                if (!scope.promise || !scope.promise.$$state || scope.promise.$$state.status)
+                {
+                    scope.promise = scope.debouncedNgClick();
+                }
+            });
+        }
+    }
+})();

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -99,6 +99,7 @@
   <script src="directives/focus-if.js"></script>
   <script src="directives/selectInputText.js"></script>
   <script src="directives/copy-to-clipboard.js"></script>
+  <script src="directives/debounced-ng-click.js"></script>
   <script src="filters/numberFormat.js"></script>
   <script src="services/auth.js"></script>
   <script src="services/linkUtilities.js"></script>

--- a/src/wwwroot/partials/signup/confirmationPage.html
+++ b/src/wwwroot/partials/signup/confirmationPage.html
@@ -71,7 +71,7 @@
           <span class="input--error" ng-show="vm.submitted && form.checkTerms.$error.required"><i class="arrow--up"></i>{{'validation_error_required' | translate}}</span>
         </div>
         <div class="wrapper-input">
-          <input class="button button--medium" ng-click="vm.submitActivation(form, vm.userName, vm.apiKey)" type="submit" value="{{'confirmation_submit' | translate}}" />
+          <input class="button button--medium" debounced-ng-click="vm.submitActivation(form, vm.userName, vm.apiKey)" type="submit" value="{{'confirmation_submit' | translate}}" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Background
On activation page, if the user clicks on the confirmation button several times, it generates several API calls

# Changes done
- Add new `debounced-ng-click` directive in charge of preventing new submits if a promise is in progress
- Adjust `submitActivation` function so it returns a promise

# Pending to be done
If this approach is approved we should consider using this directive in every element that causes an API call. In those cases, we should adjust controller code so the involved functions returns a promise