### PR TITLE
DR-897 - Fix Spanish amount deliveries is not displayed

### DIFF
--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -283,7 +283,7 @@
   "billing_address_title": "Información de Facturación",
   "my_plan_pricing_chart": "Tabla de precios",
   "my_plan_pricing_chart_description": "Selecciona la cantidad de correos electrónicos que enviará, compara los diferentes planes y encuentra la mejor opción para tus necesidades.",
-  "my_plan_pricing_chart_slider_title": "<span class='special'>{{vm.emailsSuggestedAmount | number | numberFormat}}</span> Emails por mes",
+  "my_plan_pricing_chart_slider_title": "<span class='special'>{{emailsSuggestedAmount | number | numberFormat}}</span> Emails por mes",
   "buy_now": "Comprar ahora",
   "cost_email":"Costo por email:",
   "attr_api": "Conexión API & SMTP",


### PR DESCRIPTION
Hi team,
I fix the amount deliveries per month is not displayed in the Spanish language
![2017-06-09_1633](https://user-images.githubusercontent.com/6796523/26991761-0c64721e-4d32-11e7-9391-80956bd6e304.png)

Could you review?