### PR TITLE
Dr 1178 - Fix credit card icons not visible in Firefox

### DIFF
--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -27,11 +27,9 @@ class BillingPage {
     this._ccNumberConfirmationLabel = $('.billing--plan-confirmation #ccNumberConfirmation');
     this._expDateConfirmationLabel = $('.billing--plan-confirmation #expDateConfirmation');
     this._secCodeConfirmationLabel = $('.billing--plan-confirmation #secCodeConfirmation');
-    this._ccIconAmex = $('.icon-amex');
-    this._ccIconVisa = $('.icon-visa');
-    this._ccIconMaster = $('.icon-master');
     this._modifyButton = $('.billing--plan-confirmation .modify-button');
     this._countrySelect =  element(by.id('country'));
+    this._creditCardContainer = $('.credit-card');
   }
 
   getPlanName() {
@@ -71,13 +69,22 @@ class BillingPage {
     return this._secCodeInput.sendKeys(secCode);
   }
   isCcIconVisaDisplayed() {
-    return this._ccIconVisa.isDisplayed();
+    return this.hasCreditCardActiveClass('visa');
   }
   isCcIconMastercardDisplayed() {
-    return this._ccIconMaster.isDisplayed();
+    return this.hasCreditCardActiveClass('mastercard');
   }
   isCcIconAmexDisplayed() {
-    return this._ccIconAmex.isDisplayed();
+    return this.hasCreditCardActiveClass('amex');
+  }
+  hasCreditCardActiveClass(name) {
+    var hasClass = this._creditCardContainer
+      .getAttribute('class')
+      .then(function(className) {
+        return className.indexOf(name) >= 0;
+      });
+      
+    return hasClass;
   }
   clickCheckOrder() {
     return this._checkOrderButton.click();

--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -569,9 +569,6 @@
       svg {
         margin-top: torem(4px);
       }
-      .width--full {
-        margin-top: -1.6em;
-      }
     }
   }
   .billing--plan-confirmation{

--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -569,6 +569,9 @@
       svg {
         margin-top: torem(4px);
       }
+      .width--full {
+        margin-top: -1.6em;
+      }
     }
   }
   .billing--plan-confirmation{
@@ -596,7 +599,7 @@
     }
     .billing--first-container{
       margin-bottom: 1rem;
-      max-height: 125.5rem;
+      max-height: 132rem;
     }
   }
   .billing--container{

--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -448,23 +448,27 @@
 .credit-card--container {
   .credit-card {
     align-items: center;
-    svg { display: none; }
     &.visa {
       svg.icon-visa {
-        display: block;
+        -webkit-filter: none; 
+        filter: none;
       }
     }
     &.mastercard {
       svg.icon-master {
-        display: block;
+        -webkit-filter: none; 
+        filter: none;
       }
     }
     &.amex {
       svg.icon-amex {
-        display: block;
+        -webkit-filter: none; 
+        filter: none;
       }
     }
     svg.icon {
+      -webkit-filter: grayscale(100%);
+      filter: grayscale(100%);
       margin-left: 1.5em;
     }
   }


### PR DESCRIPTION
Hi team

I resolved the icons should be displayed in Firefox browser, also when the system detects the credit card, the icon should change the colour
 Pending: Update the tests
Examples:
![2017-06-23_1640](https://user-images.githubusercontent.com/6796523/27497850-f3bce2b2-5832-11e7-93fb-dcb1ddf5bf32.png)
![2017-06-23_1640_001](https://user-images.githubusercontent.com/6796523/27497858-fb87fca2-5832-11e7-8836-c8ca7ad410f4.png)
![2017-06-23_1641](https://user-images.githubusercontent.com/6796523/27497861-ff74895c-5832-11e7-8d18-57619700a6fd.png)

Could you review?
