### PR TITLE
[DR-1225] - Add /status/plan endpoint in the App

### DIFF
--- a/src/protractor-conf-builder.js
+++ b/src/protractor-conf-builder.js
@@ -64,6 +64,7 @@ var defaultsForCapability = {
 function onPrepare() {
   // TODO: We have to do this because in SauceLabs the screen size is not working correctly.
   browser.driver.manage().window().setSize(1280, 960);
+  browser.driver.manage().window().maximize();
   browser.addMockModule('commonModule', () => angular
     .module('commonModule', ['ngMockE2E'])
     .run(($httpBackend, jwtHelper, auth) => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -476,7 +476,7 @@ describe('Billing Page', () => {
     expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('50');
     expect(billingPage.getMonthConsumption()).toBe('200');
     expect(billingPage.getExtraEmails()).toBe('150');
-    expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01');
+    expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
   });
 
   it('should show correct plan status values for Free Trial user', () => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -33,8 +33,11 @@ describe('Billing Page', () => {
               "fee": 0,
               "includedDeliveries": 50.0
         });
-        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/deliveries/).respond(200, {
-              "itemsCount": 200
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+               "deliveriesCount": 200,
+               "startDate": "2017-07-01T01:01:01Z",
+               "endDate": "2017-08-01T01:01:01Z"
         });
       }));
   }
@@ -468,21 +471,12 @@ describe('Billing Page', () => {
     setupSamplePlanInfoResponse();
     setupSamplePlansResponse();
     var billingPage = new BillingPage();
-    var dateConcat = '';
-    var date = new Date();
-    var month = ('0' + (date.getMonth() + 1 + 1)).slice(-2);
-    var year = date.getFullYear();
-    if (month > 12) {
-      month = '01';
-      year = year + 1;
-    }
-    dateConcat = dateConcat.concat(year,'-', month, '-', '01');
 
     // Assert
     expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('50');
     expect(billingPage.getMonthConsumption()).toBe('200');
     expect(billingPage.getExtraEmails()).toBe('150');
-    expect(billingPage.getRenewalDate()).toBe(dateConcat);
+    expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01');
   });
 
   it('should show correct plan status values for Free Trial user', () => {

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -54,12 +54,11 @@
     }
 
     function getMonthConsumption() {
-      var firstDayFromLastMonth = moment().utc().startOf('month');
-      return reports.getRecords(firstDayFromLastMonth, null, null, 5)
+      return settings.getStatusPlanInfo()
           .then(function (result) {
             vm.extraEmailsSent = 0;
-            vm.resetDate = moment().utc().add(1, 'month').startOf('month').format('YYYY-MM-DD');
-            vm.currentMonthlyCount = result.deliveriesCount;
+            vm.resetDate = result.data.endDate;
+            vm.currentMonthlyCount = result.data.myConsumption;
             vm.planStatusInfoLoader = false;
             if (vm.currentPlanEmailsAmount < vm.currentMonthlyCount) {
               vm.extraEmailsSent = vm.currentMonthlyCount - vm.currentPlanEmailsAmount;

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -58,7 +58,7 @@
           .then(function (result) {
             vm.extraEmailsSent = 0;
             vm.resetDate = result.data.endDate;
-            vm.currentMonthlyCount = result.data.myConsumption;
+            vm.currentMonthlyCount = result.data.deliveriesCount;
             vm.planStatusInfoLoader = false;
             if (vm.currentPlanEmailsAmount < vm.currentMonthlyCount) {
               vm.extraEmailsSent = vm.currentMonthlyCount - vm.currentPlanEmailsAmount;

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -41,7 +41,7 @@
       </div>
       <div class="flex two flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_renewal_date' | translate }}</label>
-        <p class="renewal-date">{{ vm.resetDate | amUtc | amDateFormat:'YYYY-MM-DD HH:mm' }}</p>
+        <p class="renewal-date">{{ vm.resetDate | amUtc | amDateFormat:'YYYY-MM-DD HH:mm Z' }}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
     </div>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -41,7 +41,7 @@
       </div>
       <div class="flex two flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_renewal_date' | translate }}</label>
-        <p class="renewal-date">{{vm.resetDate}}</p>
+        <p class="renewal-date">{{ vm.resetDate | amUtc | amDateFormat:'YYYY-MM-DD HH:mm' }}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
     </div>

--- a/src/wwwroot/services/settings.js
+++ b/src/wwwroot/services/settings.js
@@ -21,7 +21,8 @@
       getDomain: getDomain,
       getPlansAvailable: getPlansAvailable,
       billingPayment: billingPayment,
-      getCurrentPlanInfo: getCurrentPlanInfo
+      getCurrentPlanInfo: getCurrentPlanInfo,
+      getStatusPlanInfo: getStatusPlanInfo
     };
 
     var plansCache = null;
@@ -168,6 +169,14 @@
         actionDescription: 'action_getting_current_plan',
         method: 'GET',
         url: RELAY_CONFIG.baseUrl + '/accounts/' + auth.getAccountName() + '/agreements' + '/current'
+      });
+    }
+
+    function getStatusPlanInfo() {
+      return $http({
+        actionDescription: 'action_getting_status_plan',
+        method: 'GET',
+        url: RELAY_CONFIG.baseUrl + '/accounts/' + auth.getAccountName() + '/status' + '/plan'
       });
     }
 }


### PR DESCRIPTION
Hi Team,
The My Consumption and Plan Renewal fields in My plan section through a new endpoint GET `account/status/plan`
Example:

![2017-07-17_1220](https://user-images.githubusercontent.com/6796523/28282484-f75e1aae-6b00-11e7-83db-5778cbb48760.png)

Now, the hour is displayed in PLAN RENEWAL

Could you review?