### PR TITLE
[Hot Fix] [DR-1158] Make API calls through HTTPS only

### DIFF
--- a/src/wwwroot/env/INT.js
+++ b/src/wwwroot/env/INT.js
@@ -1,5 +1,5 @@
 ﻿angular.module('dopplerRelay').constant('RELAY_CONFIG', {
-    baseUrl: 'http://dopplerrelayint.makingsense.com:8080',
+    baseUrl: 'https://dopplerrelayint.makingsense.com:4443',
     hostSmtp: 'dopplerrelayint.makingsense.com',
     portSmtp: '2525'
 });

--- a/src/wwwroot/env/PROD.js
+++ b/src/wwwroot/env/PROD.js
@@ -1,5 +1,5 @@
 ﻿angular.module('dopplerRelay').constant('RELAY_CONFIG', {
-  baseUrl: 'http://api.dopplerrelay.com',
+  baseUrl: 'https://api.dopplerrelay.com',
   hostSmtp: 'smtp.dopplerrelay.com',
   portSmtp: '587'
 });

--- a/src/wwwroot/env/QA.js
+++ b/src/wwwroot/env/QA.js
@@ -1,5 +1,5 @@
 ﻿angular.module('dopplerRelay').constant('RELAY_CONFIG', {
-  baseUrl: 'http://dopplerrelayqa.makingsense.com:8080',
+  baseUrl: 'https://dopplerrelayqa.makingsense.com:4443',
   hostSmtp: 'dopplerrelayqa.makingsense.com',
   portSmtp: '2525'
 });


### PR DESCRIPTION
## Background

This PR is intended to change the URL set up in the configuration files to make the calls through HTTPS in order to avoid the browser security errors