### PR TITLE
[DR-1245] - Add separators for numbers in my plan section

### DIFF
--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -496,6 +496,43 @@ describe('Billing Page', () => {
     expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
   });
 
+   it('should show correct plan status values with big numbers', () => {
+
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    browser.addMockModule('descartableModule4', () => angular
+      // This code will be executed in the browser context,
+      // so it cannot access variables from outside its scope
+      .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2016-07-01T00:00:00Z",
+              "currency": "USD",
+              "extraDeliveryCost": 0.00002000,
+              "fee": 31.80,
+              "includedDeliveries": 12000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+               "deliveriesCount": 20000000,
+               "startDate": "2017-07-01T01:01:01Z",
+               "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+
+    // Assert
+    expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('12,000');
+    expect(billingPage.getMonthConsumption()).toBe('20,000,000');
+    expect(billingPage.getExtraEmails()).toBe('19,988,000');
+    expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
+  });
+
   it('should show correct plan status values for Free Trial user', () => {
 
     // Arrange

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -533,6 +533,43 @@ describe('Billing Page', () => {
     expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
   });
 
+   it('should show correct plan status values with big numbers in spanish', () => {
+
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K&lang=es');
+    browser.addMockModule('descartableModule4', () => angular
+      // This code will be executed in the browser context,
+      // so it cannot access variables from outside its scope
+      .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2016-07-01T00:00:00Z",
+              "currency": "USD",
+              "extraDeliveryCost": 0.00002000,
+              "fee": 31.80,
+              "includedDeliveries": 12000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+               "deliveriesCount": 20000000,
+               "startDate": "2017-07-01T01:01:01Z",
+               "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+
+    // Assert
+    expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('12.000');
+    expect(billingPage.getMonthConsumption()).toBe('20.000.000');
+    expect(billingPage.getExtraEmails()).toBe('19.988.000');
+    expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
+  });
+
   it('should show correct plan status values for Free Trial user', () => {
 
     // Arrange

--- a/src/wwwroot/filters/commaToDot.js
+++ b/src/wwwroot/filters/commaToDot.js
@@ -1,0 +1,12 @@
+(function () {
+    'use strict';
+
+    angular
+      .module('dopplerRelay')
+      .filter('commaToDot', function () {
+          return function (input) {
+            var ret=(input)?input.toString().replace(/,/g,"."):null;
+            return ret;
+          };
+      });
+})();

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -107,6 +107,7 @@
   <script src="directives/copy-to-clipboard.js"></script>
   <script src="directives/debounced-ng-click.js"></script>
   <script src="filters/numberFormat.js"></script>
+  <script src="filters/commaToDot.js"></script>
   <script src="services/auth.js"></script>
   <script src="services/linkUtilities.js"></script>
   <script src="services/reports.js"></script>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -15,13 +15,13 @@
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'amount_of_emails_text' | translate }}</label>
-        <p class="emails-amount">{{vm.currentPlanEmailsAmount}}</p>
+        <p class="emails-amount">{{vm.currentPlanEmailsAmount | number | numberFormat}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_cost_email' | translate }}</label>
         <p ng-show="vm.isFreeTrial">-</p>
-        <p ng-show="!vm.isFreeTrial">{{vm.currency}} {{vm.currentPlanEmailPrice}}</p>
+        <p ng-show="!vm.isFreeTrial">{{vm.currency}} {{vm.currentPlanEmailPrice | number | numberFormat}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
@@ -31,12 +31,12 @@
     <div class="item flex flex--wrap">
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_consumption' | translate }}</label>
-        <p class="month-consumption">{{vm.currentMonthlyCount}}</p>
+        <p class="month-consumption">{{vm.currentMonthlyCount | number | numberFormat}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_emails_sent' | translate }}</label>
-        <p class="extra-emails">{{vm.extraEmailsSent}}</p>
+        <p class="extra-emails">{{vm.extraEmailsSent | number | numberFormat}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex two flex--wrap">

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -15,13 +15,14 @@
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'amount_of_emails_text' | translate }}</label>
-        <p class="emails-amount">{{vm.currentPlanEmailsAmount | number | numberFormat}}</p>
+        <p class="emails-amount" ng-if="vm.langUsed == 'es'">{{vm.currentPlanEmailsAmount | number | commaToDot}}</p>
+        <p class="emails-amount" ng-if="vm.langUsed == 'en'">{{vm.currentPlanEmailsAmount | number}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_cost_email' | translate }}</label>
         <p ng-show="vm.isFreeTrial">-</p>
-        <p ng-show="!vm.isFreeTrial">{{vm.currency}} {{vm.currentPlanEmailPrice | number | numberFormat}}</p>
+        <p ng-show="!vm.isFreeTrial">{{vm.currency}} {{vm.currentPlanEmailPrice}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
@@ -31,12 +32,14 @@
     <div class="item flex flex--wrap">
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_consumption' | translate }}</label>
-        <p class="month-consumption">{{vm.currentMonthlyCount | number | numberFormat}}</p>
+        <p class="month-consumption" ng-if="vm.langUsed == 'en'">{{vm.currentMonthlyCount | number}}</p>
+        <p class="month-consumption" ng-if="vm.langUsed == 'es'">{{vm.currentMonthlyCount | number | commaToDot}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_emails_sent' | translate }}</label>
-        <p class="extra-emails">{{vm.extraEmailsSent | number | numberFormat}}</p>
+        <p class="extra-emails" ng-if="vm.langUsed == 'en'">{{vm.extraEmailsSent | number}}</p>
+        <p class="extra-emails" ng-if="vm.langUsed == 'es'">{{vm.extraEmailsSent | number | commaToDot}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex two flex--wrap">


### PR DESCRIPTION
Hi team,
I add separator to numbers in my plan section

Example:

![2017-07-21_1046](https://user-images.githubusercontent.com/6796523/28466274-4c8b8206-6e02-11e7-9960-fbe93ae15d6c.png)

Could you review?