### PR TITLE
[DR-1253] - Add separator numbers by language

### DIFF
--- a/src/protractor-conf-builder.js
+++ b/src/protractor-conf-builder.js
@@ -64,7 +64,6 @@ var defaultsForCapability = {
 function onPrepare() {
   // TODO: We have to do this because in SauceLabs the screen size is not working correctly.
   browser.driver.manage().window().setSize(1280, 960);
-  browser.driver.manage().window().maximize();
   browser.addMockModule('commonModule', () => angular
     .module('commonModule', ['ngMockE2E'])
     .run(($httpBackend, jwtHelper, auth) => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -98,7 +98,7 @@ describe('Billing Page', () => {
 
     // Assert
     expect(plan).toBe('PLAN-60K');
-    expect(billingPage.getPrice()).toBe('USD 31.80 por mes');
+    expect(billingPage.getPrice()).toBe('USD 31,80 por mes');
   });
 
   it('should show credit card icon when complete visa credit card number', () => {
@@ -537,7 +537,7 @@ describe('Billing Page', () => {
 
     // Arrange
     beginAuthenticatedSession();
-    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    browser.get('/#/settings/my-plan?plan=PLAN-60K&lang=es');
     browser.addMockModule('descartableModule4', () => angular
       .module('descartableModule4', ['ngMockE2E'])
       .run($httpBackend => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -533,6 +533,43 @@ describe('Billing Page', () => {
     expect(billingPage.getExtraEmails()).toBe('19,988,000');
   });
 
+  it('should show correct plan status values with number separators in spanish', () => {
+
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    browser.addMockModule('descartableModule4', () => angular
+      .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2016-07-01T00:00:00Z",
+              "currency": "USD",
+              "extraDeliveryCost": 0.00002000,
+              "fee": 122231.80,
+              "includedDeliveries": 12000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+               "deliveriesCount": 20000000,
+               "startDate": "2017-07-01T01:01:01Z",
+               "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+
+    // Assert
+    expect(billingPage.getCurrentPlanPrice()).toBe('USD 122.231,80');
+    expect(billingPage.getCurrentPlanEmailPrice()).toBe('USD 0,00002000');
+    expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('12.000');
+    expect(billingPage.getMonthConsumption()).toBe('20.000.000');
+    expect(billingPage.getExtraEmails()).toBe('19.988.000');
+  });
+
   it('should show correct plan status values for Free Trial user', () => {
 
     // Arrange

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -496,6 +496,43 @@ describe('Billing Page', () => {
     expect(billingPage.getRenewalDate()).toBe('2017-08-01 01:01 +00:00');
   });
 
+  it('should show correct plan status values with number separators in english', () => {
+
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    browser.addMockModule('descartableModule4', () => angular
+      .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2016-07-01T00:00:00Z",
+              "currency": "USD",
+              "extraDeliveryCost": 0.00002000,
+              "fee": 122231.80,
+              "includedDeliveries": 12000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+               "deliveriesCount": 20000000,
+               "startDate": "2017-07-01T01:01:01Z",
+               "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+
+    // Assert
+    expect(billingPage.getCurrentPlanPrice()).toBe('$ 122,231.80');
+    expect(billingPage.getCurrentPlanEmailPrice()).toBe('$ 0.00002000');
+    expect(billingPage.getEmailsAmountForCurrentPlan()).toBe('12,000');
+    expect(billingPage.getMonthConsumption()).toBe('20,000,000');
+    expect(billingPage.getExtraEmails()).toBe('19,988,000');
+  });
+
   it('should show correct plan status values for Free Trial user', () => {
 
     // Arrange

--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -44,8 +44,16 @@ class BillingPage {
     this._renewalDate = $('.renewal-date');
     this._emailsAmount = $('.emails-amount');
     this._myPlanPriceFreeTrial = $('.my-plan-price');
+    this._currentPlanEmailPrice = element(by.css('.current-plan-email-price p:nth-child(3)'));
+    this._currentPlanPrice = element(by.css('.current-plan-price p:nth-child(3)'));
   }
 
+  getCurrentPlanEmailPrice() {
+    return this._currentPlanEmailPrice.getText();
+  }
+  getCurrentPlanPrice() {
+    return this._currentPlanPrice.getText();
+  }
   getPlanName() {
     return this._planName.getText();
   }

--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -44,8 +44,8 @@ class BillingPage {
     this._renewalDate = $('.renewal-date');
     this._emailsAmount = $('.emails-amount');
     this._myPlanPriceFreeTrial = $('.my-plan-price');
-    this._currentPlanEmailPrice = element(by.css('.current-plan-email-price p:nth-child(3)'));
-    this._currentPlanPrice = element(by.css('.current-plan-price p:nth-child(3)'));
+    this._currentPlanEmailPrice = element(by.css('.email-price p:nth-child(3)'));
+    this._currentPlanPrice = element(by.css('.price p:nth-child(3)'));
   }
 
   getCurrentPlanEmailPrice() {

--- a/src/spec/settings_spec.js
+++ b/src/spec/settings_spec.js
@@ -179,6 +179,9 @@ describe('Settings Page', () => {
     //Act
     browser.get('/#/settings/domain-manager');
     var countDomainListItems = settings.countDomainListItems();
+    
+    // Move to scroll in the delete button
+    browser.executeScript('window.scrollTo(94,188);');
     settings.clickFirstDeleteButton();
 
     //Assert

--- a/src/wwwroot/app.js
+++ b/src/wwwroot/app.js
@@ -23,7 +23,34 @@
     .filter('escapeURI', function(){
       return window.encodeURIComponent;
     })
-    .config(['$routeProvider', '$translateProvider', '$locationProvider', '$httpProvider', 'jwtInterceptorProvider', 'uiSelectConfig', 'tooltipsConfProvider', function ($routeProvider, $translateProvider, $locationProvider, $httpProvider, jwtInterceptorProvider, uiSelectConfig, tooltipsConfProvider) {
+    .config([
+      '$routeProvider', 
+      '$translateProvider', 
+      '$locationProvider', 
+      '$httpProvider', 
+      'jwtInterceptorProvider', 
+      'uiSelectConfig', 
+      'tooltipsConfProvider',
+      '$provide',
+      function (
+        $routeProvider,
+        $translateProvider,
+        $locationProvider,
+        $httpProvider,
+        jwtInterceptorProvider,
+        uiSelectConfig,
+        tooltipsConfProvider,
+        $provide) {
+
+      function makeStateful($delegate) {
+        $delegate.$stateful = true;
+        return $delegate;
+      }
+
+      $provide.decorator('dateFilter', ['$delegate', makeStateful]);
+      $provide.decorator('numberFilter', ['$delegate', makeStateful]);
+      $provide.decorator('currencyFilter', ['$delegate', makeStateful]);
+
 
       //  $locationProvider.html5Mode(true); //this apply HTML5MODE
       uiSelectConfig.theme = 'selectize';
@@ -133,7 +160,30 @@
 
     }]);
 
-  dopplerRelayModule.run(['$rootScope', 'auth', '$location', '$translate', 'jwtHelper', function ($rootScope, auth, $location, $translate, jwtHelper) {
+  dopplerRelayModule.run([
+    '$rootScope', 
+    'auth', 
+    '$location', 
+    '$translate', 
+    'jwtHelper', 
+    '$locale',
+    function (
+      $rootScope,
+      auth,
+      $location, 
+      $translate, 
+      jwtHelper,
+      $locale) {
+
+    function applyCulture() {
+      $locale.NUMBER_FORMATS.DECIMAL_SEP = $translate.instant("NUMBER_FORMATS.DECIMAL_SEP");
+      $locale.NUMBER_FORMATS.GROUP_SEP = $translate.instant("NUMBER_FORMATS.GROUP_SEP");
+    }
+
+    applyCulture();
+
+    $rootScope.$on('$translateChangeEnd', applyCulture);
+
     $rootScope.$on('$locationChangeStart', function () {
       var queryParams = $location.search();
 

--- a/src/wwwroot/app.js
+++ b/src/wwwroot/app.js
@@ -175,14 +175,14 @@
       jwtHelper,
       $locale) {
 
-    function applyCulture() {
-      $locale.NUMBER_FORMATS.DECIMAL_SEP = $translate.instant("NUMBER_FORMATS.DECIMAL_SEP");
-      $locale.NUMBER_FORMATS.GROUP_SEP = $translate.instant("NUMBER_FORMATS.GROUP_SEP");
+    function applyCultureFormats() {
+      $locale.NUMBER_FORMATS.DECIMAL_SEP = $translate.instant("CULTURE_FORMATS.NUMBER_FORMATS.DECIMAL_SEP");
+      $locale.NUMBER_FORMATS.GROUP_SEP = $translate.instant("CULTURE_FORMATS.NUMBER_FORMATS.GROUP_SEP");
     }
 
-    applyCulture();
+    applyCultureFormats();
 
-    $rootScope.$on('$translateChangeEnd', applyCulture);
+    $rootScope.$on('$translateChangeEnd', applyCultureFormats);
 
     $rootScope.$on('$locationChangeStart', function () {
       var queryParams = $location.search();

--- a/src/wwwroot/app.js
+++ b/src/wwwroot/app.js
@@ -1,6 +1,10 @@
 (function () {
   'use strict';
 
+  function getLocale(lang) {
+    return window['relay-translation-' + lang];
+  }
+
   var dopplerRelayModule = angular
     .module('dopplerRelay', [
         'ngRoute',
@@ -147,8 +151,8 @@
         });
 
       $translateProvider
-        .translations('en', window["relay-translation-en"])
-        .translations('es', window["relay-translation-es"])
+        .translations('en', getLocale('en'))
+        .translations('es', getLocale('es'))
         .preferredLanguage('en')
         .useSanitizeValueStrategy('sanitizeParameters');
 
@@ -176,8 +180,8 @@
       $locale) {
 
     function applyCultureFormats() {
-      $locale.NUMBER_FORMATS.DECIMAL_SEP = $translate.instant("CULTURE_FORMATS.NUMBER_FORMATS.DECIMAL_SEP");
-      $locale.NUMBER_FORMATS.GROUP_SEP = $translate.instant("CULTURE_FORMATS.NUMBER_FORMATS.GROUP_SEP");
+      var locale = getLocale($translate.use());
+      angular.merge($locale, locale['CULTURE_FORMATS']);
     }
 
     applyCultureFormats();

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -309,5 +309,9 @@
   "success_upgrade_title":"Congratulations!",
   "success_upgrade_text":"Your payment has been processed correctly, we will send you the receipt soon. If you have any doubt please reach out us at <a href='mailto:soporte@dopplerrelay.com'>support@dopplerrelay.com.</a>",
   "success_upgrade_button":"Go to my plan!",
-  "USD":"$"
+  "USD":"$",
+  "NUMBER_FORMATS": {
+    "DECIMAL_SEP": ".",
+    "GROUP_SEP": ","
+  }
 };

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -310,8 +310,10 @@
   "success_upgrade_text":"Your payment has been processed correctly, we will send you the receipt soon. If you have any doubt please reach out us at <a href='mailto:soporte@dopplerrelay.com'>support@dopplerrelay.com.</a>",
   "success_upgrade_button":"Go to my plan!",
   "USD":"$",
-  "NUMBER_FORMATS": {
-    "DECIMAL_SEP": ".",
-    "GROUP_SEP": ","
+  "CULTURE_FORMATS": {
+    "NUMBER_FORMATS": {
+      "DECIMAL_SEP": ".",
+      "GROUP_SEP": ","
+    }
   }
 };

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -323,5 +323,9 @@
   "success_upgrade_title":"¡Felicitaciones!",
   "success_upgrade_text":"El pago ha sido aceptado correctamente, te enviaremos tu comprobante de pago en breve. Si tienes alguna duda puedes ponerte en contacto con nuestro equipo escribiendo a <a href='mailto:soporte@dopplerrelay.com'>soporte@dopplerrelay.com.</a>",
   "success_upgrade_button": "¡Ir a mi plan!",
-  "USD":"USD"
+  "USD":"USD",
+  "NUMBER_FORMATS": {
+    "DECIMAL_SEP": ",",
+    "GROUP_SEP": "."
+  }
 };

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -324,8 +324,10 @@
   "success_upgrade_text":"El pago ha sido aceptado correctamente, te enviaremos tu comprobante de pago en breve. Si tienes alguna duda puedes ponerte en contacto con nuestro equipo escribiendo a <a href='mailto:soporte@dopplerrelay.com'>soporte@dopplerrelay.com.</a>",
   "success_upgrade_button": "¡Ir a mi plan!",
   "USD":"USD",
-  "NUMBER_FORMATS": {
-    "DECIMAL_SEP": ",",
-    "GROUP_SEP": "."
+  "CULTURE_FORMATS": {
+    "NUMBER_FORMATS": {
+      "DECIMAL_SEP": ",",
+      "GROUP_SEP": "."
+    }
   }
 };

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -7,21 +7,21 @@
   </div>
   <div class="section--wrapper my-plan--info-container">
     <div class="item flex flex--wrap first">
-      <div class="flex one flex--wrap">
+      <div class="flex one flex--wrap current-plan-price">
         <label class="width--full special uppercase">{{ 'price_text' | translate }}</label>
         <p ng-show="vm.isFreeTrial" class="my-plan-price">{{'free_trial_text' | translate}}</p>
-        <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanPrice}}</p>
+        <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanPrice | number:2}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'amount_of_emails_text' | translate }}</label>
-        <p class="emails-amount">{{vm.currentPlanEmailsAmount}}</p>
+        <p class="emails-amount">{{vm.currentPlanEmailsAmount | number}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
-      <div class="flex one flex--wrap">
+      <div class="flex one flex--wrap current-plan-email-price">
         <label class="width--full special uppercase">{{ 'my_plan_cost_email' | translate }}</label>
         <p ng-show="vm.isFreeTrial">-</p>
-        <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanEmailPrice}}</p>
+        <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanEmailPrice | number:8}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
@@ -31,12 +31,12 @@
     <div class="item flex flex--wrap">
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_consumption' | translate }}</label>
-        <p class="month-consumption">{{vm.currentMonthlyCount}}</p>
+        <p class="month-consumption">{{vm.currentMonthlyCount | number}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
         <label class="width--full special uppercase">{{ 'my_plan_emails_sent' | translate }}</label>
-        <p class="extra-emails">{{vm.extraEmailsSent}}</p>
+        <p class="extra-emails">{{vm.extraEmailsSent | number}}</p>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex two flex--wrap">

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -7,7 +7,7 @@
   </div>
   <div class="section--wrapper my-plan--info-container">
     <div class="item flex flex--wrap first">
-      <div class="flex one flex--wrap current-plan-price">
+      <div class="flex one flex--wrap price">
         <label class="width--full special uppercase">{{ 'price_text' | translate }}</label>
         <p ng-show="vm.isFreeTrial" class="my-plan-price">{{'free_trial_text' | translate}}</p>
         <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanPrice | number:2}}</p>
@@ -18,7 +18,7 @@
         <p class="emails-amount">{{vm.currentPlanEmailsAmount | number}}</p>
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
-      <div class="flex one flex--wrap current-plan-email-price">
+      <div class="flex one flex--wrap email-price">
         <label class="width--full special uppercase">{{ 'my_plan_cost_email' | translate }}</label>
         <p ng-show="vm.isFreeTrial">-</p>
         <p ng-show="!vm.isFreeTrial">{{vm.currency | translate}} {{vm.currentPlanEmailPrice | number:8}}</p>


### PR DESCRIPTION
Hi team,
I added the format separator number in all WebApp by language

This repository has a code to the use of this PR - angular-dynamic-locale code
https://github.com/lgalfaso/angular-dynamic-locale/blob/master/src/tmhDynamicLocale.js#L18

Example
https://user-images.githubusercontent.com/6796523/28466274-4c8b8206-6e02-11e7-9960-fbe93ae15d6c.png

Configuration i18n
Spanish
https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.6.5/angular-locale_es-419.js
English
https://cdnjs.cloudflare.com/ajax/libs/angular-i18n/1.6.5/angular-locale_en-150.js

Could you review?