### PR TITLE
[DR-1260] Change display when spinner is not showed in mobile

### DIFF
--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -588,7 +588,10 @@
   .my-plans--container{
     .my-plan--info-container{
       .item {
-        div {margin-top: 1em;}
+        div {          
+          margin-top: 1em;
+          .hide{display: none;}
+        }
         div:first-of-type { margin-top: 0; }
       }
        .item:first-of-type {


### PR DESCRIPTION
# OverView
 Remove horizontal scoll when the user goes to my plan in a mobile resolution. (this was caused by the spinner)

# Changes
 - Change display when mobile resolution is being used and the spinner should be hidden.