### PR TITLE
[DR-1267] Add My plan link into submenu with false state

### DIFF
--- a/src/wwwroot/controllers/BillingCtrl.js
+++ b/src/wwwroot/controllers/BillingCtrl.js
@@ -34,6 +34,7 @@
     var vm = this;
     $rootScope.setSubmenues([
       { text: 'submenu_my_profile', url: 'settings/my-profile', active: false },
+      { text: 'submenu_my_plan', url: 'settings/my-plan', active: false }
     ]);
     var queryParams = $location.search();
     var planName = queryParams['plan'];


### PR DESCRIPTION
# Overview
 This is a fix for the meantime we decide what to do with that submenu.

# Change:
 - Add my plan link into submenu, so the user can go back without using the dropdown on the right top.