### PR TITLE
[DR-1283] Add new informational header

### DIFF
--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -66,6 +66,9 @@ describe('Billing Page', () => {
           ]
         });
        $httpBackend.whenGET(/\/resources\/countries\.json/).respond(200, [{"code": "BV","en": "Bolivia, Plurinational State Of","es": "Bolivia"}]);
+       $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+         "data" : ""
+      });
       }));
   }
 

--- a/src/spec/confirmation_spec.js
+++ b/src/spec/confirmation_spec.js
@@ -33,6 +33,13 @@ describe('Confirmation Page', () => {
   it('should load drop downs in different languages', () => {
 
     // Arrange
+    browser.addMockModule('descartableModule2', () => angular
+    .module('descartableModule2', ['ngMockE2E'])
+    .run($httpBackend => {
+      $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+        "data" : ""
+      });
+    }));
     var confirmationPage = new ConfirmationPage();
     var industryInEnglish = "Tobacco";
     var industryInSpanish = "Tabaco";

--- a/src/spec/forgot-password_spec.js
+++ b/src/spec/forgot-password_spec.js
@@ -22,6 +22,9 @@ describe('Forgot password', () => {
       .module('descartableModule', ['ngMockE2E'])
       .run($httpBackend => {
         $httpBackend.whenPUT(/\/user\/password\/recover/).respond(500, {});
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "data" : ""
+       });
       }));
 
     var loginPage = new LoginPage();
@@ -45,6 +48,9 @@ describe('Forgot password', () => {
         $httpBackend.whenPUT(/\/user\/password\/recover/).respond(201, {
           'message': 'We have sent an email to your email address to continue with the registration process...'
         });
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "data" : ""
+       });
       }));
 
     var loginPage = new LoginPage();

--- a/src/spec/login_spec.js
+++ b/src/spec/login_spec.js
@@ -4,6 +4,13 @@ describe('Login page', () => {
   it('should show switch language message in inverse language', () => {
 
     // Arrange
+    browser.addMockModule('descartableModule', () => angular
+    .module('descartableModule', ['ngMockE2E'])
+    .run($httpBackend => {
+      $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+        "data" : ""
+     });
+    }));
     var loginPage = new LoginPage();
     var inEnglish = "Speak English? Change it here";
     var inSpanish = "¿Hablas Español? Cámbialo aquí";
@@ -38,6 +45,9 @@ describe('Login page', () => {
         $httpBackend.whenPUT(/\/user\/password\/recover/).respond(201, {
           'message': 'We have sent an email to your email address to continue with the registration process...'
         });
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "data" : ""
+       });
       }));
 
     var loginPage = new LoginPage();

--- a/src/spec/settings_spec.js
+++ b/src/spec/settings_spec.js
@@ -15,10 +15,14 @@ describe('Settings Page', () => {
   function beginAuthenticatedSession() {
     browser.addMockModule('descartableModule', () => angular
       .module('descartableModule', [])
-      .run((jwtHelper, auth) => {
+      .run((jwtHelper, auth, $httpBackend) => {
         var permanentToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjE0ODQ2MzAzMTgsImV4cCI6MTQ4NzIyMjMxOCwiaWF0IjoxNDg0NjMwMzE4LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjM0NzUxIiwic3ViIjoxMDAzLCJ1bmlxdWVfbmFtZSI6ImFtb3NjaGluaUBtYWtpbmdzZW5zZS5jb20iLCJyZWxheV9hY2NvdW50cyI6WyJhbW9zY2hpbmktbWFraW5nc2Vuc2UiXSwicmVsYXlfdG9rZW5fdmVyc2lvbiI6IjEuMC4wLWJldGE1In0.dQh20ukVSCP0rNXMWBh2DlPQXbP0uTaYzadRDNPXECI9lvCsgDKNXc2bToXAUQDeXw90kbHliVF-kCueW4gQLPBtMJOcHQFv6LfgspsG2jue2iMwoBC1q6UB_4xFlGoyhkRjldnQUV0oqBTzhFdXuTvQz53kRPiqILCHkd4FLl4KliBgdaDRwWz-HIjJwinMpnv_7V38CNvHlHo-q2XU0MnE3CsGXmWGoAgzN7rbeQPgI9azHXpbaUPh9n_4zjCydOSBC5tx7MtEAx3ivfFYImBPp2T2vUM-F5AwRh7hl_lMUvyQLal0S_spoT0XMGy8YhnjxXLoZeVRisWbxBmucQ';
         auth.saveToken(permanentToken);
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "data" : ""
+       });
       }));
+      
   }
   it('should show "add domain" input when you click in add domain button', () => {
     //Arrange

--- a/src/wwwroot/controllers/HeaderCtrl.js
+++ b/src/wwwroot/controllers/HeaderCtrl.js
@@ -26,40 +26,6 @@
     };
     $scope.getSubmenues = $rootScope.getSubmenues;
     $scope.isSubmenuVisible = $rootScope.isSubmenuVisible;
-
-    UpdateTrialHeader();
-    
-    function UpdateTrialHeader() {
-      $scope.isFreeTrialEnded = false;
-      $scope.isFreeTrialAlmostEnded = false;
-      $scope.isFreeTrial = false;
-      return $rootScope.freeTrialEndDate().then(function(freeTrialEndDate) {
-        var todayDate = moment().toDate();
-        var daysLeft = moment(freeTrialEndDate).diff(todayDate, "days");
-        $scope.isFreeTrial = freeTrialEndDate ? true : false;
-        $scope.trialDaysLeft = daysLeft;
-        if (freeTrialEndDate <= todayDate) {
-          $scope.isFreeTrialEnded = true;
-          $scope.isFreeTrialAlmostEnded = false;
-          $scope.showFreeTrialHeader = false;
-        }
-        if (daysLeft <= 10 && daysLeft >= 0 && freeTrialEndDate > todayDate) {
-          $scope.isFreeTrialAlmostEnded = true;
-          $scope.isFreeTrialEnded = false;
-          $scope.showFreeTrialHeader = false;
-        }
-
-        if (freeTrialEndDate && !$scope.isFreeTrialEnded && !$scope.isFreeTrialAlmostEnded) {
-          $scope.showFreeTrialHeader = true;
-          $scope.isFreeTrialEnded = false;
-          $scope.isFreeTrialAlmostEnded = false;
-        }
-      });
-    }
-    
-    
-
-    
     $scope.initialsAvatar = function () {
       var fullName = $rootScope.getFullName();
       if (!fullName) {

--- a/src/wwwroot/controllers/HeaderCtrl.js
+++ b/src/wwwroot/controllers/HeaderCtrl.js
@@ -26,6 +26,40 @@
     };
     $scope.getSubmenues = $rootScope.getSubmenues;
     $scope.isSubmenuVisible = $rootScope.isSubmenuVisible;
+
+    UpdateTrialHeader();
+    
+    function UpdateTrialHeader() {
+      $scope.isFreeTrialEnded = false;
+      $scope.isFreeTrialAlmostEnded = false;
+      $scope.isFreeTrial = false;
+      return $rootScope.freeTrialEndDate().then(function(freeTrialEndDate) {
+        var todayDate = moment().toDate();
+        var daysLeft = moment(freeTrialEndDate).diff(todayDate, "days");
+        $scope.isFreeTrial = freeTrialEndDate ? true : false;
+        $scope.trialDaysLeft = daysLeft;
+        if (freeTrialEndDate <= todayDate) {
+          $scope.isFreeTrialEnded = true;
+          $scope.isFreeTrialAlmostEnded = false;
+          $scope.showFreeTrialHeader = false;
+        }
+        if (daysLeft <= 10 && daysLeft >= 0 && freeTrialEndDate > todayDate) {
+          $scope.isFreeTrialAlmostEnded = true;
+          $scope.isFreeTrialEnded = false;
+          $scope.showFreeTrialHeader = false;
+        }
+
+        if (freeTrialEndDate && !$scope.isFreeTrialEnded && !$scope.isFreeTrialAlmostEnded) {
+          $scope.showFreeTrialHeader = true;
+          $scope.isFreeTrialEnded = false;
+          $scope.isFreeTrialAlmostEnded = false;
+        }
+      });
+    }
+    
+    
+
+    
     $scope.initialsAvatar = function () {
       var fullName = $rootScope.getFullName();
       if (!fullName) {
@@ -39,3 +73,4 @@
     }
   }
 })();
+

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -17,6 +17,8 @@
   ];
 
   function MainCtrl($rootScope, $scope, $window, $location, auth, $log, ModalService, $route) {
+    $rootScope.freeTrialEndDate = auth.getFreeTrialEndDate;
+    
     $rootScope.getLoggedUserEmail = function () {
       return auth.getUserName();
     };

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -29,47 +29,57 @@
     };
      
     var loaderFreeTrial = function () {
-      auth.updateLocalStorage().then(function(freeTrialEndDate){
-        UpdateTrialHeader(freeTrialEndDate);
+      auth.getLimitsByAccount().then(function(limits){          
+        if (limits.freeTrialEndDate) {
+          UpdateTrialHeader(limits.freeTrialEndDate);
+        }
       });
     }
     loaderFreeTrial();
     $interval(loaderFreeTrial, 10000);
 
+    $rootScope.freeTrialStatus = null;
 
-  function UpdateTrialHeader(freeTrialEndDate) {
-    $rootScope.isFreeTrialEnded = false;
-    $rootScope.isFreeTrialAlmostEnded = false;
-    $rootScope.isFreeTrialHeader = false;
-    $rootScope.isFreeTrialEndToday = false;    
+  function UpdateTrialHeader(freeTrialEndDate) {    
+    if (!freeTrialEndDate) {
+      $rootScope.freeTrialStatus = null;
+      return;
+    }
+
     var todayDate = moment().toDate();
     var daysLeft = moment(freeTrialEndDate).diff(todayDate, "days");
-    $rootScope.isFreeTrialHeader = !!freeTrialEndDate.freeTrialEndDate;
-    $rootScope.trialDaysLeft = daysLeft;
+
+    $rootScope.freeTrialStatus = {
+      trialDaysLeft : daysLeft,
+      isFreeTrialEnded : false,
+      isFreeTrialAlmostEnded : false,
+      isFreeTrialEndToday : false
+    }
 
     if (moment(freeTrialEndDate) <= todayDate) {
-      $rootScope.isFreeTrialEnded = true;
-      $rootScope.isFreeTrialAlmostEnded = false;
-      $rootScope.showFreeTrialHeader = false;
-      $rootScope.isFreeTrialEndToday = false;
+      $rootScope.freeTrialStatus = {
+        trialDaysLeft : daysLeft,
+        isFreeTrialEnded : true,
+        isFreeTrialAlmostEnded : false,
+        isFreeTrialEndToday : false
+      }
+      
     }
     if (daysLeft <= 10 && daysLeft > 0) {
-      $rootScope.isFreeTrialAlmostEnded = true;
-      $scope.isFreeTrialEnded = false;
-      $scope.showFreeTrialHeader = false;
-      $rootScope.isFreeTrialEndToday = false;
+      $rootScope.freeTrialStatus = {
+        trialDaysLeft : daysLeft,
+        isFreeTrialEnded : false,
+        isFreeTrialAlmostEnded : true,
+        isFreeTrialEndToday : false
+      }
     }
     if (daysLeft == 0) {
-      $rootScope.isFreeTrialEndToday = true;
-      $rootScope.isFreeTrialAlmostEnded = false;
-      $scope.isFreeTrialEnded = false;
-      $scope.showFreeTrialHeader = false;
-    }
-    if (freeTrialEndDate && !$rootScope.isFreeTrialEnded && !$rootScope.isFreeTrialAlmostEnded && daysLeft != 0) {
-      $rootScope.showFreeTrialHeader = true;
-      $rootScope.isFreeTrialEnded = false;
-      $rootScope.isFreeTrialAlmostEnded = false;
-      $rootScope.isFreeTrialEndToday = false;
+      $rootScope.freeTrialStatus = {
+        trialDaysLeft : daysLeft,
+        isFreeTrialEnded : false,
+        isFreeTrialAlmostEnded : false,
+        isFreeTrialEndToday : true
+      }
     }
 }
 

--- a/src/wwwroot/index.html
+++ b/src/wwwroot/index.html
@@ -39,7 +39,7 @@
 </head>
 <body ng-controller="MainCtrl">
   <header id="header" ng-controller="HeaderCtrl" ng-class="{true: 'logged',false: 'login'}[isAuthed()]" ng-include="'partials/header.html'"></header>
-  <main class="main-container ms-relay" ng-view ng-class="isSubmenuVisible() ? 'with-submenu': ''"></main>
+  <main class="main-container ms-relay" ng-view ng-class="[{true: 'with-submenu'}[isSubmenuVisible()],{true:'with-submenu-and-free-trial',false:'with-free-trial-submenu'}[isSubmenuVisible() && isFreeTrial()]]"></main>
   <footer id="footer" class="footer" ng-include="'partials/footer.html'"></footer>
   <!-- inject:js -->
   <!-- When you update it, please remember to edit karma.conf.js and gulpfile.js -->

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -396,5 +396,6 @@
   "free_trial_header_ended_text": "Your Free Trial has ended, please to keep sending your transactional emails do an upgrade.",
   "upgrade_plan_exclamation": "Upgrade now!",
   "free_trial_header_almost_ended_text" : "Your free trial is ending in {{ trialDaysLeft }} days, please to keep sending your transactional emails do an upgrade.",
-  "free_trial_header_trial_text": "Your account is on the free trial version, if need to send more emails choose a plan."
+  "free_trial_header_end_today_text" : "Your free trial is ending today, please to keep sending your transactional emails do an upgrade.",
+  "free_trial_header_trial_text": "Your account is on the free trial version, if you need to send more emails choose a plan."
 };

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -392,5 +392,9 @@
   "contact_us_text": "Contact Us",
   "contact_premium_plan_subject": "Doppler Relay Premium Quote",
   "daily_limit_title": "Daily sending limit",
-  "daily_limit_used": "Emails sent today"
+  "daily_limit_used": "Emails sent today",
+  "free_trial_header_ended_text": "Your Free Trial has ended, please to keep sending your transactional emails do an upgrade.",
+  "upgrade_plan_exclamation": "Upgrade now!",
+  "free_trial_header_almost_ended_text" : "Your free trial is ending in {{ trialDaysLeft }} days, please to keep sending your transactional emails do an upgrade.",
+  "free_trial_header_trial_text": "Your account is on the free trial version, if need to send more emails choose a plan."
 };

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -406,5 +406,9 @@
   "contact_us_text": "Contáctanos",
   "contact_premium_plan_subject": "Consulta Doppler Relay Premium",
   "daily_limit_title": "Límite de envío diario",
-  "daily_limit_used": "Consumo diario realizado"
+  "daily_limit_used": "Consumo diario realizado",
+  "free_trial_header_ended_text": "Tu prueba gratuita ha terminado, para continuar enviando tus Emails Transaccionales contrata un plan.",
+  "upgrade_plan_exclamation": "¡Contrata ahora!",
+  "free_trial_header_almost_ended_text" : "Tu prueba gratuita termina en {{ trialDaysLeft }} días, para seguir enviando tus emails transaccionales elige un plan.",
+  "free_trial_header_trial_text": "Tu cuenta se encuentra en la versión de prueba gratuita, si necesitas enviar más emails elige un plan."
 };

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -410,5 +410,6 @@
   "free_trial_header_ended_text": "Tu prueba gratuita ha terminado, para continuar enviando tus Emails Transaccionales contrata un plan.",
   "upgrade_plan_exclamation": "¡Contrata ahora!",
   "free_trial_header_almost_ended_text" : "Tu prueba gratuita termina en {{ trialDaysLeft }} días, para seguir enviando tus emails transaccionales elige un plan.",
+  "free_trial_header_end_today_text" : "Tu prueba gratuita termina hoy, para seguir enviando tus emails transaccionales elige un plan.",
   "free_trial_header_trial_text": "Tu cuenta se encuentra en la versión de prueba gratuita, si necesitas enviar más emails elige un plan."
 };

--- a/src/wwwroot/partials/header.html
+++ b/src/wwwroot/partials/header.html
@@ -1,11 +1,12 @@
 ﻿      <!--<a ng-click="logOut()">Log Out</a>-->
-<section class="header free-trial ms-relay" ng-if="isFreeTrial">
+<section class="header free-trial ms-relay" ng-if="isFreeTrialHeader">
   <div class="flex flex--center">
     <p>
       <strong>
         <span ng-show="isFreeTrialEnded">{{'free_trial_header_ended_text' | translate}}</span>
         <span ng-show="isFreeTrialAlmostEnded">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:trialDaysLeft} }}</span>
         <span ng-show="showFreeTrialHeader">{{'free_trial_header_trial_text' | translate}}</span>
+        <span ng-show="isFreeTrialEndToday">{{'free_trial_header_end_today_text' | translate}}</span>        
       </strong>
     </p>
     <a class="button button--extra-small button--white" href="#/settings/my-plan">

--- a/src/wwwroot/partials/header.html
+++ b/src/wwwroot/partials/header.html
@@ -1,4 +1,19 @@
 ﻿      <!--<a ng-click="logOut()">Log Out</a>-->
+<section class="header free-trial ms-relay" ng-if="isFreeTrial">
+  <div class="flex flex--center">
+    <p>
+      <strong>
+        <span ng-show="isFreeTrialEnded">{{'free_trial_header_ended_text' | translate}}</span>
+        <span ng-show="isFreeTrialAlmostEnded">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:trialDaysLeft} }}</span>
+        <span ng-show="showFreeTrialHeader">{{'free_trial_header_trial_text' | translate}}</span>
+      </strong>
+    </p>
+    <a class="button button--extra-small button--white" href="#/settings/my-plan">
+      <strong>{{'upgrade_plan_exclamation' | translate}}</strong>
+    </a>
+  </div>
+</section>
+
 <section class="header no-padding ms-relay" ng-class="isPermanentAuthed() ? 'logged' : 'login'">
   <div class="section--wrapper">
     <nav>

--- a/src/wwwroot/partials/header.html
+++ b/src/wwwroot/partials/header.html
@@ -1,12 +1,12 @@
 ﻿      <!--<a ng-click="logOut()">Log Out</a>-->
-<section class="header free-trial ms-relay" ng-if="isFreeTrialHeader">
+<section class="header free-trial ms-relay" ng-if="freeTrialStatus">
   <div class="flex flex--center">
     <p>
       <strong>
-        <span ng-show="isFreeTrialEnded">{{'free_trial_header_ended_text' | translate}}</span>
-        <span ng-show="isFreeTrialAlmostEnded">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:trialDaysLeft} }}</span>
-        <span ng-show="showFreeTrialHeader">{{'free_trial_header_trial_text' | translate}}</span>
-        <span ng-show="isFreeTrialEndToday">{{'free_trial_header_end_today_text' | translate}}</span>        
+        <span ng-show="freeTrialStatus.isFreeTrialEnded">{{'free_trial_header_ended_text' | translate}}</span>
+        <span ng-show="freeTrialStatus.isFreeTrialAlmostEnded">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:freeTrialStatus.trialDaysLeft} }}</span>
+        <span ng-show="freeTrialStatus.isFreeTrialEndToday">{{'free_trial_header_end_today_text' | translate}}</span>
+        <span ng-show="!freeTrialStatus.isFreeTrialEnded && !freeTrialStatus.isFreeTrialAlmostEnded && !freeTrialStatus.isFreeTrialEndToday">{{'free_trial_header_trial_text' | translate}}</span>
       </strong>
     </p>
     <a class="button button--extra-small button--white" href="#/settings/my-plan">

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -31,7 +31,7 @@
       resetPassword: resetPassword,
       getApiToken: getApiToken,
       changePassword: changePassword,
-      getFreeTrialEndDate: getFreeTrialEndDate
+      updateLocalStorage: updateLocalStorage
     };
 
     var decodedToken = null;
@@ -217,20 +217,37 @@
       });
     }
 
-    function getFreeTrialEndDate() {
+    function getLimitsByAccount() {
       return $http({
         actionDescription: 'Gathering Free Trial end date',
         method: 'GET',
         url: RELAY_CONFIG.baseUrl + '/accounts/' + getAccountName()  + '/status/limits'
       }).then(function (response) {
-        if (!response.data.freeTrialEndDate){
-          return null;
-        }
-        return moment(response.data.freeTrialEndDate).toDate();
-      })
-      .catch(function (reason) {
-        return $q.reject(reason);
+        return response;
       });
+    }
+
+    function updateLocalStorage() {
+      return getLimitsByAccount().then(function(limits) {        
+      var freeTrialEndDate = getStoreInStorage('FreeTrialExpiredNotificatedOn');
+      if (!freeTrialEndDate) {
+        storeInStorage(limits.freeTrialEndDate);
+        return getStoreInStorage('FreeTrialExpiredNotificatedOn');
+      }
+      if (limits.freeTrialEndDate != freeTrialEndDate) {
+        storeInStorage(limits.freeTrialEndDate);
+        return getStoreInStorage('FreeTrialExpiredNotificatedOn');
+      }
+      return freeTrialEndDate;
+      });
+    }
+
+    function storeInStorage(key) {
+      $window.localStorage.setItem('FreeTrialExpiredNotificatedOn', key);
+    }
+
+    function getStoreInStorage(key) {
+      return $window.localStorage.getItem(key);
     }
   }
 })();

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -11,9 +11,10 @@
     '$q',
     'jwtHelper',
     'RELAY_CONFIG',
-    '$rootScope'
+    '$rootScope',
+    'moment'
   ];
-  function auth($http, $window, $q, jwtHelper, RELAY_CONFIG, $rootScope) {
+  function auth($http, $window, $q, jwtHelper, RELAY_CONFIG, $rootScope, moment) {
 
     var authService = {
       saveToken: saveToken,
@@ -29,7 +30,8 @@
       forgotPassword: forgotPassword,
       resetPassword: resetPassword,
       getApiToken: getApiToken,
-      changePassword: changePassword
+      changePassword: changePassword,
+      getFreeTrialEndDate: getFreeTrialEndDate
     };
 
     var decodedToken = null;
@@ -212,6 +214,22 @@
           "old_password": old_pass,
           "password": newPass
         }
+      });
+    }
+
+    function getFreeTrialEndDate() {
+      return $http({
+        actionDescription: 'Gathering Free Trial end date',
+        method: 'GET',
+        url: RELAY_CONFIG.baseUrl + '/accounts/' + getAccountName()  + '/status/limits'
+      }).then(function (response) {
+        if (!response.data.freeTrialEndDate){
+          return null;
+        }
+        return moment(response.data.freeTrialEndDate).toDate();
+      })
+      .catch(function (reason) {
+        return $q.reject(reason);
       });
     }
   }

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -30,8 +30,8 @@
       forgotPassword: forgotPassword,
       resetPassword: resetPassword,
       getApiToken: getApiToken,
-      changePassword: changePassword,
-      updateLocalStorage: updateLocalStorage
+      changePassword: changePassword,  
+      getLimitsByAccount: getLimitsByAccount
     };
 
     var decodedToken = null;
@@ -225,29 +225,6 @@
       }).then(function (response) {
         return response;
       });
-    }
-
-    function updateLocalStorage() {
-      return getLimitsByAccount().then(function(limits) {        
-      var freeTrialEndDate = getStoreInStorage('FreeTrialExpiredNotificatedOn');
-      if (!freeTrialEndDate) {
-        storeInStorage(limits.freeTrialEndDate);
-        return getStoreInStorage('FreeTrialExpiredNotificatedOn');
-      }
-      if (limits.freeTrialEndDate != freeTrialEndDate) {
-        storeInStorage(limits.freeTrialEndDate);
-        return getStoreInStorage('FreeTrialExpiredNotificatedOn');
-      }
-      return freeTrialEndDate;
-      });
-    }
-
-    function storeInStorage(key) {
-      $window.localStorage.setItem('FreeTrialExpiredNotificatedOn', key);
-    }
-
-    function getStoreInStorage(key) {
-      return $window.localStorage.getItem(key);
     }
   }
 })();

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -222,8 +222,6 @@
         actionDescription: 'Gathering Free Trial end date',
         method: 'GET',
         url: RELAY_CONFIG.baseUrl + '/accounts/' + getAccountName()  + '/status/limits'
-      }).then(function (response) {
-        return response;
       });
     }
   }

--- a/src/wwwroot/styles/core/_base.scss
+++ b/src/wwwroot/styles/core/_base.scss
@@ -55,6 +55,12 @@ p.main--subtitle{
   &.with-submenu{
     min-height: calc(100vh - 247px);
   }
+  &.with-free-trial-submenu{
+    min-height: calc(100vh - 260px);
+  }
+  &.with-submenu-and-free-trial{
+    min-height: calc(100vh - 287px);
+  }
   .selectize-input.selectize-focus {
     border-color: #C0BCB8 !important;
     background-color: #fff !important;

--- a/src/wwwroot/styles/modules/_button.scss
+++ b/src/wwwroot/styles/modules/_button.scss
@@ -86,9 +86,8 @@ $input--error--color: #FFF;
 
 	.button--size{
 		vertical-align: middle;
-
 		&.button--extra-small{
-			padding: toem(5px);
+			padding: toem(10px) toem(20px);
 			min-width: 100px;
 			font-size: $font-size-tiny;
 		}
@@ -168,7 +167,7 @@ $input--error--color: #FFF;
 			}
 		}
 		&.button--white{
-			background: transparent;
+			background: #FFF;
 			color: $suit-accent-color;
 			border-color: $suit-accent-color-light;
 			&:hover{

--- a/src/wwwroot/styles/views/_header.scss
+++ b/src/wwwroot/styles/views/_header.scss
@@ -145,6 +145,14 @@ header{
     font-size: $font-size-tiny !important;
     margin-right: 2em !important;
   }
+  .free-trial{
+    padding: torem(9px);
+    background: $suit-accent-color;
+    color: $suit-font-color-bright;
+    a { 
+      margin-left: torem(15px);
+    }
+  }
 }
 
 @media screen and (max-height: 750px){


### PR DESCRIPTION
# Overview
 Add new trial informational header letting the user know when it's in a trial account, about to end and in an ended account.

# Changes
 - Add free trial date to Rootscope so we can use it again in Reports Limits.
 - Add behaviour to show the correct text
 - Responsive ready.
 - Service ready to show the header as soon as we give to the webapp a freeTrialEndDate without making any changes.