### PR TITLE
[DR-1371] Remove trial period banner on logout

### DIFF
--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -153,6 +153,7 @@
 
     $rootScope.logOut = function () {
       auth.logOut();
+      loadLimits();
       $location.path('/login');
     };
 

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -31,12 +31,9 @@
     var modalOpened = false;
     
     var loaderFreeTrial = function () {
-      if (auth.getUserName() != null) {
-        auth.getLimitsByAccount()
-        .then(function(limit) {
-          UpdateTrialHeader(limit.endDate);
-        });
-      }
+      auth.getLimitsByAccount().then(function(limit) {
+        UpdateTrialHeader(limit.endDate);
+      });
     }
     loaderFreeTrial();
     $interval(loaderFreeTrial, 10000);

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -30,13 +30,13 @@
     var freeTrialNotification = auth.getFreeTrialNotificationFromStorage();
     var modalOpened = false;
     
-    var loaderFreeTrial = function () {
+    var loadLimits = function () {
       auth.getLimitsByAccount().then(function(limit) {
         UpdateTrialHeader(limit.endDate);
       });
     }
-    loaderFreeTrial();
-    $interval(loaderFreeTrial, 10000);
+    loadLimits();
+    $interval(loadLimits, 10000);
 
     $rootScope.freeTrialStatus = null;
 

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -34,9 +34,7 @@
       if (auth.getUserName() != null) {
         auth.getLimitsByAccount()
         .then(function(limit) {
-          if (limit.endDate) {
-            UpdateTrialHeader(moment(limit.endDate).toDate());
-          }
+          UpdateTrialHeader(limit.endDate);
         });
       }
     }

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -220,10 +220,17 @@
     }
 
     function getLimitsByAccount() {
+      var accountName = getAccountName();
+
+      if (!accountName) {
+        // limits have no sense in this scenario
+        return $q.when({});
+      }
+
       return $http({
         actionDescription: 'Gathering Free Trial end date',
         method: 'GET',
-        url: RELAY_CONFIG.baseUrl + '/accounts/' + getAccountName()  + '/status/limits'
+        url: RELAY_CONFIG.baseUrl + '/accounts/' + accountName  + '/status/limits'
       })
       .then(function (response) {
         return {

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -226,9 +226,38 @@
         url: RELAY_CONFIG.baseUrl + '/accounts/' + getAccountName()  + '/status/limits'
       })
       .then(function (response) {
-        return response.data;
+        return {
+          monthly: mapLimit(response.data.monthly),
+          daily: mapLimit(response.data.daily),
+          hourly: mapLimit(response.data.hourly),
+          noLimits: !!response.data.noLimits,
+          endDate: mapDate(response.data.endDate)
+        };
       });
-    }   
+    }
+
+    function mapLimit(responseLimit)
+    {
+      if (!responseLimit) {
+        return null;
+      }
+
+      return {
+        limit: responseLimit.limit,
+        remaining: responseLimit.remaining,
+        reset: mapDate(responseLimit.reset)
+      }
+    }
+
+    function mapDate(responseDate)
+    {
+      if (!responseDate) {
+        return null;
+      }
+
+      // TODO: parse date without using moment
+      return (moment(responseDate).toDate())
+    }
 
     function addFreeTrialNotificationToStorage(date) {
       $window.localStorage.setItem('freeTrialNotificationOn', date);


### PR DESCRIPTION
Hi @mvillaseco, @nreal and @alegarciamina,

As @nreal found yesterday, we were not cleaning free trial header after logout:

![2017-09-27_1627](https://user-images.githubusercontent.com/1157864/30979027-b5970604-a452-11e7-8622-d6ed391f6bdd.png)

This code fixes that and also removes the header if the user upgrades the account. 

I have also applied a little code refactoring.

Could you kindly review?
