### PR TITLE
[DR-1393] Allow upgrades on webapp

### DIFF
--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -505,6 +505,46 @@ describe('Billing Page', () => {
     expect(billingPage.isDetachedErrorDisplayed()).toBeTruthy();
   });
 
+  it('should not show change plan button when agreement is scheduled', () => {
+    
+        // Arrange
+        beginAuthenticatedSession();        
+        browser.addMockModule('descartableModule4', () => angular
+        // This code will be executed in the browser context,
+        // so it cannot access variables from outside its scope
+        .module('descartableModule4', ['ngMockE2E'])
+          .run($httpBackend => {
+            $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+                  "planName": null,
+                  "paymentMethod": null,
+                  "billingInformation": null,
+                  "startDate": "2017-07-01T00:00:00Z",
+                  "endDate": "2017-08-01T00:00:00Z",
+                  "currency": "USD",
+                  "ips_count": 0,
+                  "cost_by_ip": 0,
+                  "extraDeliveryCost": 0,
+                  "fee": 50,
+                  "includedDeliveries": 75000
+            });
+    
+            $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+                  "deliveriesCount": 200,
+                  "startDate": "2017-07-01T01:01:01Z",
+                  "endDate": "2017-08-01T01:01:01Z"
+            });
+          }));
+        
+        setupSamplePlansResponse();
+        var billingPage = new BillingPage();
+    
+        //Act
+        browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    
+        // Assert
+        expect(billingPage.isChangePlanButtonDisplayed()).toBeFalsy();
+      });
+  
   it('should show the pricing chart when the user click on upgrade button', () => {
 
     // Arrange

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -62,7 +62,12 @@ describe('Billing Page', () => {
               "fee": 31.8,
               "extra_delivery_cost": 0.00053000,
               "included_deliveries": 60000.0,
-              "name": "PLAN-60K" }
+              "name": "PLAN-60K" },
+              { "currency": "USD",
+              "fee": 51.8,
+              "extra_delivery_cost": 0.00051000,
+              "included_deliveries": 80000.0,
+              "name": "PLAN-80K" }
           ]
         });
        $httpBackend.whenGET(/\/resources\/countries\.json/).respond(200, [{"code": "BV","en": "Bolivia, Plurinational State Of","es": "Bolivia"}]);
@@ -222,6 +227,58 @@ describe('Billing Page', () => {
     expect(billingPage.getFirstCountryName()).toBe(countryInEnglish);
 
   });
+
+  it('should show billing information if available', () => {
+    
+        // Arrange
+        beginAuthenticatedSession();
+        setupSamplePlansResponse();
+        //setupSamplePlanInfoResponse();
+        
+        browser.addMockModule('descartableModule4', () => angular
+        // This code will be executed in the browser context,
+        // so it cannot access variables from outside its scope
+        .module('descartableModule4', ['ngMockE2E'])
+          .run($httpBackend => {
+            $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+                  "planName": null,
+                  "paymentMethod": null,
+                  "billingInformation": {
+                    "name": "Test",
+                    "companyName": "Test Upgrade",
+                    "address": "Address 1234",
+                    "city": "Rosario",
+                    "zipCode": "2000",
+                    "countryCode": "AR"
+                  },
+                  "startDate": "2017-07-01T00:00:00Z",
+                  "currency": "USD",
+                  "ips_count": 0,
+                  "cost_by_ip": 0,
+                  "extraDeliveryCost": 0,
+                  "fee": 1,
+                  "includedDeliveries": 50
+            });
+    
+            $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+                  "deliveriesCount": 200,
+                  "startDate": "2017-07-01T01:01:01Z",
+                  "endDate": "2017-08-01T01:01:01Z"
+            });
+          }));
+    
+        // Act
+        browser.get('/#/settings/billing?plan=PLAN-60K&lang=en');
+    
+        // Assert
+        var billingPage = new BillingPage();
+
+        expect(billingPage.getName()).toBe('Test');
+        expect(billingPage.getCompany()).toBe('Test Upgrade');
+        expect(billingPage.getAddress()).toBe('Address 1234');
+        expect(billingPage.getCity()).toBe('Rosario');
+        expect(billingPage.getZCode()).toBe('2000');
+      });
 
   it('should show the confirmation page with all the fields filled', () => {
 
@@ -456,12 +513,56 @@ describe('Billing Page', () => {
     expect(billingPage.isPricingChartDisplayed()).toBeTruthy();
   });
 
-  it('should load the slider', () => {
-
+  it('should load the slider with default emails per month count selected', () => {
+    
     // Arrange
     beginAuthenticatedSession();
     browser.get('/#/settings/my-plan?plan=PLAN-60K');
     setupSamplePlanInfoResponse();
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+    var defaultPlanDeliveries = '60,000';
+
+    //Act
+    billingPage.clickUpgradeButtonToDisplayPricingChart();
+
+    // Assert
+    expect(billingPage.isSliderLoaded()).toBeTruthy();
+    expect(billingPage.getSliderEmailsPerMonth()).toBe(defaultPlanDeliveries);
+  });
+
+  it('should load the slider with default emails per month count calculated based on included deliveries', () => {
+    
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    
+    browser.addMockModule('descartableModule4', () => angular
+    // This code will be executed in the browser context,
+    // so it cannot access variables from outside its scope
+    .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2017-07-01T00:00:00Z",
+              "currency": "USD",
+              "ips_count": 0,
+              "cost_by_ip": 0,
+              "extraDeliveryCost": 0,
+              "fee": 50,
+              "includedDeliveries": 75000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+              "deliveriesCount": 200,
+              "startDate": "2017-07-01T01:01:01Z",
+              "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+    
+    
     setupSamplePlansResponse();
     var billingPage = new BillingPage();
 
@@ -470,6 +571,7 @@ describe('Billing Page', () => {
 
     // Assert
     expect(billingPage.isSliderLoaded()).toBeTruthy();
+    expect(billingPage.getSliderEmailsPerMonth()).toBe('80,000');
   });
 
   it('should change the price when the user change slider position', () => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -63,6 +63,14 @@ describe('Billing Page', () => {
               "extra_delivery_cost": 0.00053000,
               "included_deliveries": 60000.0,
               "name": "PLAN-60K" },
+            { "currency": "USD",
+              "fee": 40,
+              "extra_delivery_cost": 0.00053000,
+              "included_deliveries": 60000.0,
+              "type":"pro",
+              "ips_count":1,
+              "cost_by_ip": 5,
+              "name": "PLAN-PRO-60K" },
               { "currency": "USD",
               "fee": 51.8,
               "extra_delivery_cost": 0.00051000,
@@ -591,6 +599,49 @@ describe('Billing Page', () => {
 
     // Assert
     expect(billingPage.getPlanPrice()).not.toBe(planDefaultPrice);
+  });
+
+  it('should show a disabled button for current plan and contact us for downgrade', () => {
+    
+    // Arrange
+    beginAuthenticatedSession();
+    browser.get('/#/settings/my-plan?plan=PLAN-60K');
+    
+    browser.addMockModule('descartableModule4', () => angular
+    // This code will be executed in the browser context,
+    // so it cannot access variables from outside its scope
+    .module('descartableModule4', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current/).respond(200, {
+              "planName": null,
+              "paymentMethod": null,
+              "billingInformation": null,
+              "startDate": "2017-07-01T00:00:00Z",
+              "currency": "USD",
+              "ips_count": 1,
+              "cost_by_ip": 5,
+              "extraDeliveryCost": 0,
+              "fee": 45,
+              "includedDeliveries": 60000
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan/).respond(200, {
+              "deliveriesCount": 200,
+              "startDate": "2017-07-01T01:01:01Z",
+              "endDate": "2017-08-01T01:01:01Z"
+        });
+      }));
+    
+    
+    setupSamplePlansResponse();
+    var billingPage = new BillingPage();
+
+    //Act
+    billingPage.clickUpgradeButtonToDisplayPricingChart();
+
+    // Assert
+    expect(billingPage.getBasicButtonText()).toBe('CONTACT US');
+    expect(billingPage.isProPlanButtonDisabled()).toBeTruthy();
   });
 
   it('should show the new box for Pro and premium plan', () => {

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -206,6 +206,7 @@ describe('Billing Page', () => {
     var countryInSpanish = "Bolivia";
     beginAuthenticatedSession();
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     // Act
     browser.get('/#/settings/billing?plan=PLAN-60K&lang=es');
@@ -228,6 +229,7 @@ describe('Billing Page', () => {
     beginAuthenticatedSession();
     browser.get('/#/settings/billing?plan=PLAN-60K');
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     var billingPage = new BillingPage();
     var name = 'TestName TestLastName';
@@ -276,6 +278,7 @@ describe('Billing Page', () => {
     beginAuthenticatedSession();
     browser.get('/#/settings/billing?plan=PLAN-60K');
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     var billingPage = new BillingPage();
     var name = '';
@@ -313,6 +316,7 @@ describe('Billing Page', () => {
     beginAuthenticatedSession();
     browser.get('/#/settings/billing?plan=PLAN-60K');
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     var billingPage = new BillingPage();
     var name = 'TestName TestLastName';
@@ -355,6 +359,7 @@ describe('Billing Page', () => {
     beginAuthenticatedSession();
     browser.get('/#/settings/billing?plan=PLAN-60K');
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     var billingPage = new BillingPage();
     var name = 'TestName TestLastName';
@@ -392,6 +397,7 @@ describe('Billing Page', () => {
     beginAuthenticatedSession();
     browser.get('/#/settings/billing?plan=PLAN-60K');
     setupSamplePlansResponse();
+    setupSamplePlanInfoResponse();
 
     browser.addMockModule('descartableModule3', () => angular
       // This code will be executed in the browser context,

--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -33,6 +33,8 @@ class BillingPage {
     this._creditCardContainer = $('.credit-card');
     this._creditCardErrorContainer = $('.credit-card .validation-error-fluid');
     this._detachedError = $('.billing--plan-confirmation .detached--error-container');
+    this._basicPlanDisplayedButton = $(".plan--box-container .basic a.show");
+    this._proPlanDisplayedButton = $(".plan--box-container .pro a.show");
     //My Plan section
     this._myPlanPricingChartDisplayButton = $('.my-plan--info-container .button');
     this._pricingChartContainer = $('.pricing-chart--container');
@@ -293,6 +295,19 @@ class BillingPage {
   }
   getSliderEmailsPerMonth() {
     return this._sliderEmailsPerMonth.getText();
+  }
+  getBasicButtonText(){
+    return this._basicPlanDisplayedButton.getText();
+  }
+
+  isProPlanButtonDisabled(){
+    var hasClass = this._proPlanDisplayedButton
+    .getAttribute('class')
+    .then(function(className) {
+      return className.indexOf('button--disabled') >= 0;
+    });
+
+    return hasClass;
   }
 }
 exports.BillingPage = BillingPage;

--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -47,6 +47,7 @@ class BillingPage {
     this._rightPlanBox = $('.plan--box-container .pro');
     this._currentPlanEmailPrice = element(by.css('.email-price p:nth-child(3)'));
     this._currentPlanPrice = element(by.css('.price p:nth-child(3)'));
+    this._sliderEmailsPerMonth = $('.plan--slider-container p span.special');
   }
 
   getCurrentPlanEmailPrice() {
@@ -67,17 +68,32 @@ class BillingPage {
   setName(name) {
     return this._nameInput.sendKeys(name);
   }
+  getName() {
+    return this._nameInput.getAttribute('value')
+  }
   setCompany(company) {
     return this._companyInput.sendKeys(company);
+  }
+  getCompany() {
+    return this._companyInput.getAttribute('value')
   }
   setAddress(address) {
     return this._addressInput.sendKeys(address);
   }
+  getAddress() {
+    return this._addressInput.getAttribute('value')
+  }
   setCity(city) {
     return this._cityInput.sendKeys(city);
   }
+  getCity() {
+    return this._cityInput.getAttribute('value')
+  }
   setZCode(zCode) {
     return this._zCodeInput.sendKeys(zCode);
+  }
+  getZCode() {
+    return this._zCodeInput.getAttribute('value')
   }
   setCountry(country) {
     return this.clickFirstSelectOptionText(this._countrySelect);
@@ -274,6 +290,9 @@ class BillingPage {
   }
   isFreeTrialAsPriceDisplayed() {
     return this._myPlanPriceFreeTrial.isDisplayed();
+  }
+  getSliderEmailsPerMonth() {
+    return this._sliderEmailsPerMonth.getText();
   }
 }
 exports.BillingPage = BillingPage;

--- a/src/spec/page-objects/billing-page.js
+++ b/src/spec/page-objects/billing-page.js
@@ -239,6 +239,10 @@ class BillingPage {
     return this._myPlanPricingChartDisplayButton.click();
   }
 
+  isChangePlanButtonDisplayed(){
+    return this._myPlanPricingChartDisplayButton.isDisplayed();
+  }
+
   isPricingChartDisplayed() {
     var hasClass = this._pricingChartContainer
       .getAttribute('class')

--- a/src/wwwroot/controllers/BillingCtrl.js
+++ b/src/wwwroot/controllers/BillingCtrl.js
@@ -62,6 +62,11 @@
 
         return settings.getCurrentPlanInfo().then(function(response) {
           
+          var currentPlanPrice = response.data.fee + (response.data.ips_count * response.data.cost_by_ip || 0);
+          if(currentPlanPrice >= vm.planPrice){
+            return redirectToPlanSelection();
+          }
+
           if(response.data.billingInformation){
             vm.name = response.data.billingInformation.name;
             vm.company = response.data.billingInformation.companyName;

--- a/src/wwwroot/controllers/BillingCtrl.js
+++ b/src/wwwroot/controllers/BillingCtrl.js
@@ -59,6 +59,21 @@
         }
         vm.currentCurrency = planSelected.currency;
         vm.planPrice = planSelected.fee + (planSelected.ips_count * planSelected.cost_by_ip || 0);
+
+        return settings.getCurrentPlanInfo().then(function(response) {
+          
+          if(response.data.billingInformation){
+            vm.name = response.data.billingInformation.name;
+            vm.company = response.data.billingInformation.companyName;
+            vm.address = response.data.billingInformation.address;
+            vm.city = response.data.billingInformation.city;
+            vm.zCode = response.data.billingInformation.zipCode;            
+            vm.country = vm.resources.countries.find(function(obj){
+              return obj.code == response.data.billingInformation.countryCode;
+            });
+          }
+        });
+
       });
     }
     vm.checkExpDate = checkExpDate;

--- a/src/wwwroot/controllers/BillingCtrl.js
+++ b/src/wwwroot/controllers/BillingCtrl.js
@@ -67,10 +67,13 @@
             vm.company = response.data.billingInformation.companyName;
             vm.address = response.data.billingInformation.address;
             vm.city = response.data.billingInformation.city;
-            vm.zCode = response.data.billingInformation.zipCode;            
-            vm.country = vm.resources.countries.find(function(obj){
-              return obj.code == response.data.billingInformation.countryCode;
-            });
+            vm.zCode = response.data.billingInformation.zipCode;       
+            resources.ensureCountries().then(function(){
+              vm.country = vm.resources.countries.find(function(obj){
+                return obj.code == response.data.billingInformation.countryCode;
+              });
+            });     
+            
           }
         });
 

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -44,6 +44,7 @@
         vm.currency = response.data.currency;
         vm.isFreeTrial = response.data.fee && response.data.includedDeliveries ? false : true;
         vm.currentIpsPlanCount = response.data.ips_count || 0;
+        vm.isUpdatePlanAllowed = response.data.endDate ? false : true;
       })
       .finally(function () {
         vm.planInfoLoader = false;

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -44,11 +44,9 @@
         vm.currency = response.data.currency;
         vm.isFreeTrial = response.data.fee && response.data.includedDeliveries ? false : true;
         vm.currentIpsPlanCount = response.data.ips_count || 0;
-        vm.isUpdatePlanAllowed = response.data.endDate ? false : true;
-        if (!vm.isFreeTrial){
-          defaultPlanDeliveries = response.data.includedDeliveries.toString(); 
-          vm.hideDragMe = true;
-        }       
+        vm.allowChangePlan = !response.data.endDate;
+        vm.hideDragMe = !vm.isFreeTrial;
+        defaultPlanDeliveries = !vm.isFreeTrial ? response.data.includedDeliveries.toString() : defaultPlanDeliveries; 
       })
       .finally(function () {
         vm.planInfoLoader = false;

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -99,20 +99,25 @@
         vm.leftPlanName = pro.name;
         vm.leftPlanPrice = pro.fee + (pro.ips_count * pro.cost_by_ip || 0);
         vm.leftCostEmail = pro.extra_delivery_cost;
+        vm.disableLeftPlan = isCurrentPlan(pro);
 
         vm.rightPlanName = 'Premium';
         vm.rightCostEmail = pro.extra_delivery_cost;
+        vm.disableRightPlan = false;
       } else {
         vm.showPremiumPlanBox = false;        
 
         vm.leftPlanName = basic.name;
         vm.leftPlanPrice = basic.fee;
         vm.leftCostEmail = basic.extra_delivery_cost;
+        vm.disableLeftPlan = isCurrentPlan(basic);
+
         if (pro) {
           vm.ipsPlanCount = pro.ips_count;
           vm.rightPlanName = pro.name;
           vm.rightPlanPrice = pro.fee + (pro.ips_count * pro.cost_by_ip || 0);
           vm.rightCostEmail = pro.extra_delivery_cost;
+          vm.disableRightPlan = isCurrentPlan(pro);
         }
       }
     }
@@ -143,6 +148,11 @@
     function showPricingChart() {
         vm.pricingChartDisplayed = true;
     }
+
+    function isCurrentPlan(plan){
+      return plan.included_deliveries == vm.currentPlanEmailsAmount && vm.currentIpsPlanCount == plan.ips_count        
+    }
+
   }
 
 })();

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -45,6 +45,9 @@
         vm.isFreeTrial = response.data.fee && response.data.includedDeliveries ? false : true;
         vm.currentIpsPlanCount = response.data.ips_count || 0;
         vm.isUpdatePlanAllowed = response.data.endDate ? false : true;
+        if (!vm.isFreeTrial){
+           vm.hideDragMe = true;
+        }       
       })
       .finally(function () {
         vm.planInfoLoader = false;

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -46,7 +46,8 @@
         vm.currentIpsPlanCount = response.data.ips_count || 0;
         vm.isUpdatePlanAllowed = response.data.endDate ? false : true;
         if (!vm.isFreeTrial){
-           vm.hideDragMe = true;
+          defaultPlanDeliveries = response.data.includedDeliveries.toString(); 
+          vm.hideDragMe = true;
         }       
       })
       .finally(function () {
@@ -54,10 +55,12 @@
       });
       var getPlansAvailable = settings.getPlansAvailable().then(function(response) {
         planItems = response.data.items;
-        loadSlider();
-        changePlan(defaultPlanDeliveries);
       });
-      return Promise.all([getPlansAvailable, getCurrentPlanInfo, getMonthConsumption()]);
+      return Promise.all([getPlansAvailable, getCurrentPlanInfo, getMonthConsumption()]).then(function(){        
+        ensureValidDefaultPlanDelivery();
+        loadSlider();
+        changePlan(defaultPlanDeliveries);        
+      });
     }
 
     function getMonthConsumption() {
@@ -151,6 +154,20 @@
 
     function isCurrentPlan(plan){
       return plan.included_deliveries == vm.currentPlanEmailsAmount && vm.currentIpsPlanCount == plan.ips_count        
+    }
+
+    function ensureValidDefaultPlanDelivery(){           
+      var selectedItems = planItems.filter(function(obj){
+        return obj.included_deliveries == defaultPlanDeliveries;
+      });
+
+      if (selectedItems.length < 1) {
+        var defaultPlanSuggested = planItems.reduce(function(prev, curr) {
+          return (Math.abs(curr.included_deliveries - defaultPlanDeliveries) < Math.abs(prev.included_deliveries - defaultPlanDeliveries) ? curr : prev);
+        });    
+        
+        defaultPlanDeliveries = defaultPlanSuggested.included_deliveries.toString();
+      }      
     }
 
   }

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -98,8 +98,9 @@
         </li>
         <li class="strong">
           <h2 class="special plan--price-big">{{vm.currency | translate}} {{vm.leftPlanPrice | number:2 | numberFormat}}</h2>
-          <a ng-class="vm.leftPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'buy_now' | translate}}</a>
-          <a ng-class="vm.leftPlanPrice <= vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
+          <a ng-class="!vm.disableLeftPlan && vm.leftPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'buy_now' | translate}}</a>
+          <a ng-class="!vm.disableLeftPlan && vm.leftPlanPrice <= vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
+          <a ng-class="vm.disableLeftPlan ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'buy_now' | translate}}</a>
         </li>
       </ul>
       <ul ng-class="!vm.showPremiumPlanBox ? 'pro':'premium'">
@@ -133,8 +134,9 @@
         </li>
         <li>
           <h2 ng-class="!vm.showPremiumPlanBox ? 'show':''" class="hidden-feature special plan--price-big">{{vm.currency | translate}} {{vm.rightPlanPrice | number:2 | numberFormat}}</h2>
-          <a ng-class="!vm.showPremiumPlanBox && vm.rightPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}"><span ng-if="!vm.showPremiumPlanBox">{{'buy_now' | translate}}</a>
-          <a ng-class="vm.showPremiumPlanBox || vm.rightPlanPrice <= vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
+          <a ng-class="!vm.disableRightPlan && !vm.showPremiumPlanBox && vm.rightPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}"><span ng-if="!vm.showPremiumPlanBox">{{'buy_now' | translate}}</a>
+          <a ng-class="!vm.disableRightPlan && (vm.showPremiumPlanBox || vm.rightPlanPrice <= vm.currentPlanPrice) ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
+          <a ng-class="vm.disableRightPlan ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'buy_now' | translate}}</a>
         </li>
       </ul>
     </div>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -98,7 +98,8 @@
         </li>
         <li class="strong">
           <h2 class="special plan--price-big">{{vm.currency | translate}} {{vm.leftPlanPrice | number:2 | numberFormat}}</h2>
-          <a class="button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'buy_now' | translate}}</a>
+          <a ng-class="vm.leftPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'buy_now' | translate}}</a>
+          <a ng-class="vm.leftPlanPrice <= vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
         </li>
       </ul>
       <ul ng-class="!vm.showPremiumPlanBox ? 'pro':'premium'">
@@ -132,8 +133,8 @@
         </li>
         <li>
           <h2 ng-class="!vm.showPremiumPlanBox ? 'show':''" class="hidden-feature special plan--price-big">{{vm.currency | translate}} {{vm.rightPlanPrice | number:2 | numberFormat}}</h2>
-          <a ng-class="!vm.showPremiumPlanBox ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}"><span ng-if="!vm.showPremiumPlanBox">{{'buy_now' | translate}}</a>
-          <a ng-class="vm.showPremiumPlanBox ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
+          <a ng-class="!vm.showPremiumPlanBox && vm.rightPlanPrice > vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}"><span ng-if="!vm.showPremiumPlanBox">{{'buy_now' | translate}}</a>
+          <a ng-class="vm.showPremiumPlanBox || vm.rightPlanPrice <= vm.currentPlanPrice ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
         </li>
       </ul>
     </div>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -27,7 +27,7 @@
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
-        <button ng-show="vm.isUpdatePlanAllowed" class="button button--small" ng-class="vm.pricingChartDisplayed ? 'button--disabled' : 'active'" ng-click="vm.showPricingChart()">{{ 'change_plan_text' | translate }}</button>
+        <button ng-show="vm.allowChangePlan" class="button button--small" ng-class="vm.pricingChartDisplayed ? 'button--disabled' : 'active'" ng-click="vm.showPricingChart()">{{ 'change_plan_text' | translate }}</button>
       </div>
     </div>
     <div class="item flex flex--wrap">

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -27,7 +27,7 @@
         <spinner class="spinner" ng-class="vm.planInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex one flex--wrap">
-        <button ng-show="vm.isFreeTrial" class="button button--small" ng-class="vm.pricingChartDisplayed ? 'button--disabled' : 'active'" ng-click="vm.showPricingChart()">{{ 'change_plan_text' | translate }}</button>
+        <button ng-show="vm.isUpdatePlanAllowed" class="button button--small" ng-class="vm.pricingChartDisplayed ? 'button--disabled' : 'active'" ng-click="vm.showPricingChart()">{{ 'change_plan_text' | translate }}</button>
       </div>
     </div>
     <div class="item flex flex--wrap">

--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -323,7 +323,7 @@
           background-color: $suit-color-status-violet;
         }
         li:last-of-type {
-          a { background-color: $suit-color-status-violet; }
+          a:not(.button--disabled) { background-color: $suit-color-status-violet; }
           //padding-top: 2.75em;
         }
       }
@@ -333,7 +333,7 @@
           background-color: $suit-color-status-green;
         }
         li:last-of-type {
-          a { background-color: $suit-color-status-green; }
+          a:not(.button--disabled) { background-color: $suit-color-status-green; }
         }
       }
       &.premium {
@@ -342,7 +342,7 @@
           background-color: $suit-accent-color;
         }
          li:last-of-type {
-          a { background-color: $suit-accent-color; }
+          a:not(.button--disabled) { background-color: $suit-accent-color; }
         }
       }
     }


### PR DESCRIPTION
Hi @andresmoschini ,
I've created this PR to start reviewing the code while continue working.

Changes:

- Show  "change plan" for free or paid users, but not when there are scheduled agreements 
- Only show DragMe if it is a free trial 
- Do not allow to choose the same plan that user already has (same plan is defined by comparing includedDeliveries and currentIpsPlanCount values between plan and current agreement) 
- Do not allow to choose plans cheaper than current plan, show a Contact Us button.
- Show billing information pre-loaded if exists
- Set initial value for slider based on current plan (defaultPlanDeliveries).