### PR TITLE
[DR-1408] Error dialog callback

### DIFF
--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -115,42 +115,40 @@
     $rootScope.getFullName = auth.getFullName;
     $rootScope.getAccountId = auth.getAccountId;
 
-    $rootScope.addError = function (error, actionDescription, rejectionTitle, statusCode, errorCode, callback, buttonText) {
-      callback = callback || $route.reload;
-      ModalService.showModal({
+    var addErrorInternal = function(inputs, callback) {
+      return ModalService.showModal({
         templateUrl: 'partials/modals/error.html',
         controller: 'ErrorCtrl',
         controllerAs: 'vm',
-        inputs: {
-          description: error,
-          actionDescription: actionDescription,
-          rejectionTitle: rejectionTitle || '',
-          statusCode: statusCode,
-          errorCode: errorCode,
-          isAuthorizationModal: false,
-          buttonText: buttonText || 'error_popup_button'
-        }
+        inputs: inputs
       }).then(function (modal) {
-        modal.close.then(callback);
+        modal.close.then(callback || $route.reload);
       });
+    }
+
+    $rootScope.addError = function (error, actionDescription, rejectionTitle, statusCode, errorCode, callback, buttonText) {
+      var inputs = {
+        description: error,
+        actionDescription: actionDescription,
+        rejectionTitle: rejectionTitle || '',
+        statusCode: statusCode,
+        errorCode: errorCode,
+        isAuthorizationModal: false,
+        buttonText: buttonText || 'error_popup_button'
+      };
+      return addErrorInternal(inputs, callback);
     };
 
     $rootScope.addAuthorizationError = function (error, statusCode, errorCode, callback) {
-      ModalService.showModal({
-        templateUrl: 'partials/modals/error.html',
-        controller: 'ErrorCtrl',
-        controllerAs: 'vm',
-        inputs: {
-          description: error,
-          actionDescription: null,
-          rejectionTitle: null,
-          statusCode: statusCode,
-          errorCode: errorCode,
-          isAuthorizationModal: true
-        }
-      }).then(function (modal) {
-        modal.close.then(callback);
-      });
+      var inputs = {
+        description: error,
+        actionDescription: null,
+        rejectionTitle: null,
+        statusCode: statusCode,
+        errorCode: errorCode,
+        isAuthorizationModal: true
+      };
+      return addErrorInternal(inputs, callback);
     };
 
     $rootScope.logOut = function () {

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -122,7 +122,11 @@
         controllerAs: 'vm',
         inputs: inputs
       }).then(function (modal) {
-        modal.close.then(callback || $route.reload);
+        modal.close.then(function (result) {
+          if (result) {
+            (callback || $route.reload)();
+          }
+        });
       });
     }
 

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -143,7 +143,7 @@
       return addErrorInternal(inputs, callback);
     };
 
-    $rootScope.addAuthorizationError = function (error, statusCode, errorCode, callback) {
+    $rootScope.addAuthorizationError = function (error, statusCode, errorCode) {
       var inputs = {
         description: error,
         actionDescription: null,
@@ -152,7 +152,7 @@
         errorCode: errorCode,
         isAuthorizationModal: true
       };
-      return addErrorInternal(inputs, callback);
+      return addErrorInternal(inputs, $rootScope.logOut);
     };
 
     $rootScope.logOut = function () {

--- a/src/wwwroot/controllers/modals/ErrorCtrl.js
+++ b/src/wwwroot/controllers/modals/ErrorCtrl.js
@@ -27,8 +27,6 @@
     vm.errorCode = errorCode;
     vm.isAuthorizationModal = isAuthorizationModal;
     vm.buttonText = buttonText;
-    vm.closeModal = function() {
-      close(vm.statusCode);
-    };
+    vm.closeModal = close;
   }
 })();

--- a/src/wwwroot/controllers/modals/ErrorCtrl.js
+++ b/src/wwwroot/controllers/modals/ErrorCtrl.js
@@ -21,8 +21,8 @@
   function ErrorCtrl($scope, close, $route, description, actionDescription, rejectionTitle, statusCode, errorCode, isAuthorizationModal, buttonText) {
     var vm = this;
     vm.errorMessage = description;
-    vm.actionDescription = !actionDescription ? null : actionDescription;
-    vm.rejectionTitle = rejectionTitle ? null : rejectionTitle;
+    vm.actionDescription = actionDescription || null;
+    vm.rejectionTitle = rejectionTitle || null;
     vm.statusCode = statusCode;
     vm.errorCode = errorCode;
     vm.isAuthorizationModal = isAuthorizationModal;

--- a/src/wwwroot/interceptors/errorHandlerInterceptor.js
+++ b/src/wwwroot/interceptors/errorHandlerInterceptor.js
@@ -10,15 +10,15 @@ angular.module('dopplerRelay')
         switch (rejection.status) {
           case 401: //Unauthorized by token expired
             if (rejection.data.errorCode == 3) {
-              $rootScope.addAuthorizationError('error_handler_401.3', null, null, $rootScope.logOut);
+              $rootScope.addAuthorizationError('error_handler_401.3', null, null);
             } else {
-              $rootScope.addAuthorizationError('error_handler_401/3', rejection.status, rejection.data.errorCode, $rootScope.logOut);
+              $rootScope.addAuthorizationError('error_handler_401/3', rejection.status, rejection.data.errorCode);
             }
             break;
           case 403: //Forbidden and Unauthorized
             // TODO: The problem could be different than expired token, so maybe it is better to show a more ambiguous message
             // For example: open a new windows and login with a different user, and try to do something in the first window
-            $rootScope.addAuthorizationError('error_handler_401/3', rejection.status, rejection.data.errorCode, $rootScope.logOut);
+            $rootScope.addAuthorizationError('error_handler_401/3', rejection.status, rejection.data.errorCode);
             break;
           case 404: //Not Found
             $rootScope.addError('error_handler_404', actionDescription, rejectionTitle);

--- a/src/wwwroot/partials/modals/error.html
+++ b/src/wwwroot/partials/modals/error.html
@@ -1,17 +1,17 @@
 <div class="modal--wrapper ms-relay">
   <div class="modal--outter text--center error-container">
-    <span ng-click="vm.closeModal()">X</span>
+    <span ng-click="vm.closeModal(false)">X</span>
     <h3>{{'error_popup_title' | translate}}</h3>
     <div ng-if="!vm.isAuthorizationModal">
       <p ng-if="!vm.rejectionTitle" ng-bind-html="vm.errorMessage | translate:{action:vm.actionDescription}"></p>
       <p ng-if="vm.rejectionTitle" ng-bind-html="vm.errorMessage | translate:{action:vm.actionDescription, rejectionTitle:vm.rejectionTitle}"></p>
       <p>{{'error_popup_description' | translate}}</p>
-      <button class="button button--large button--right" ng-click="vm.closeModal()">{{vm.buttonText | translate}}</button>
+      <button class="button button--large button--right" ng-click="vm.closeModal(true)">{{vm.buttonText | translate}}</button>
     </div>
     <div ng-if="vm.isAuthorizationModal">
       <p ng-bind-html="vm.errorMessage | translate:{statusCode:vm.statusCode, errorCode:vm.errorCode}"></p>
       <p ng-bind-html="error_popup_description_401/3 | translate"></p>
-      <button class="button button--large button--right" ng-click="vm.closeModal()">{{'error_popup_button_401/3' | translate}}</button>
+      <button class="button button--large button--right" ng-click="vm.closeModal(true)">{{'error_popup_button_401/3' | translate}}</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Hi team (and mainly @mvillaseco),

Before to fix the root cause of [DR-1374](http://jira.makingsense.com/browse/DR-1374), I wanted to fix a UX issue (in my humble opinion) with our error dialogs.

Error dialog were always reloading the page on closing, but sometime we could want to keep the page with the error, for example when there are useful information there, or sometimes it generates an cycling error.

So, I have remove _callback_ execution when the user closes the dialog with `x` icon.

I have also applied some minor code refactoring.

I am still testing but I am interested in know your opinion before spend so much time.