### PR TITLE
[DR-1471] Fix pending activation error

### DIFF
--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -111,7 +111,7 @@
             $rootScope.addError('error_handler_unexpected', actionDescription, reason);
           }
           else {
-            $rootScope.addError('error_handler_unexpected_rejection', actionDescription, reason);
+            $rootScope.addError('error_handler_unexpected_rejection', actionDescription, actionTitle);
           }
           return $q.reject(reason);
         }


### PR DESCRIPTION
Fix error modal rejection title on login by passing text instead of object to `$rootScope.addError`