### PR TITLE
Hotfix warning text

### DIFF
--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -447,7 +447,7 @@
   "login_admin_email_account_placeholder": "Enter Email or Account Name from the client",
   "login_error_invalid_impersonate": "Invalid client Email or Account Name",
   "login_error_invalid_account_impersonate": "Account not valid to impersonate",
-  "domain_not_ready_header_text": "Your account is still inactive, to start sending emails you must verify your domain by configuring your DKIM, SPF and Subdomain tracking.",
+  "domain_not_ready_header_text": "You have to configure your DKIM, SPF and tracking subdomain to verify your domain.",
   "domain_not_ready_header_button": "Configure now",
   "domain_manager_remember_hours_update": "Remember that the DKIM status can take up to 24 hours to update.",
   "domain_manager_remember_hours_tracking_domain_update": "Remember this status can take up to 24 hours to update.",

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -461,7 +461,7 @@
   "login_admin_email_account_placeholder": "Escribe el email o nombre de cuenta del usuario",
   "login_error_invalid_impersonate": "Email o nombre de cuenta invalido del Cliente",
   "login_error_invalid_account_impersonate": "Cuenta no válida para impersonar",
-  "domain_not_ready_header_text": "Tu cuenta se encuentra inactiva aún, para empezar a realizar envíos debes verificar tu dominio configurando tu DKIM, SPF y Subdominio de seguimiento.",
+  "domain_not_ready_header_text": "Tienes que configurar tu DKIM, SPF y subdominio de seguimiento para verificar tu dominio.",
   "domain_not_ready_header_button": "Configurar ahora",
   "domain_manager_remember_hours_update": "Recuerda que puede tardar hasta 24 horas en actualizarse el status del DKIM.",
   "domain_manager_remember_hours_tracking_domain_update": "Recuerda que puede tardar hasta 24 horas en actualizarse el estado.",


### PR DESCRIPTION
Hi @mvillaseco, could you review this changes?

My idea is to apply today in prod, there should be no rendering problems, right?

And a language question. @Juampi1790 defined this message: 

_You have to configure your DKIM, SPF and **subdomain tracking** to verify your domain_

But in my opinion it should be: 

_You have to configure your DKIM, SPF and **tracking subdomain** to verify your domain_

What do you think?