### PR TITLE
[DR-1551] Fix wrong regex in templates profile

### DIFF
--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -71,7 +71,7 @@
           defaultUrl: "/reports"
         };
         case "templates": return {
-          acceptedUrlsPattern: /^#?\/templates\/?(\?.*)?$/,
+          acceptedUrlsPattern: /^#?\/templates(\/.*)?$/,
           defaultUrl: "/templates"
         };
         case "settings": return {


### PR DESCRIPTION
# Overview:
 Fix issue with regex when user have a templates profile. Now we will allow anything after /templates/ and /templates only(without the '/')
