### PR TITLE
[DR-1551] Fix issue with revision numbers replacing templates string

### DIFF
--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -65,12 +65,14 @@
     }
 
     function expandPermissions(profile) {
+      // TODO: Review why the revision numbers are being added into the word templates in this file.
+      var TEMPLATES = " templates ".trim();
       switch (profile) {
         case "reports": return {
           acceptedUrlsPattern: /^#?\/reports\/?(\?.*)?$|^#?\/reports\/downloads\/?(\?.*)?$/,
           defaultUrl: "/reports"
         };
-        case "templates": return {
+        case TEMPLATES: return {
           acceptedUrlsPattern: /^#?\/templates(\/.*)?$/,
           defaultUrl: "/templates"
         };


### PR DESCRIPTION
# Overview
It seems that we have a problem with the gulp task that adds the revision numbers, it's currently adding it into any templates string inside auth.js(maybe in all services).

This is an ugly but working fix. I add also a TODO to research this, buy for now, we can go with this solution.
