### PR TITLE
Feature/dr-1561-require ready domains

### DIFF
--- a/src/spec/page-objects/new-plan.js
+++ b/src/spec/page-objects/new-plan.js
@@ -5,6 +5,8 @@ class MyPlanPage {
       this._pricingChartContainer = $('.pricing-chart--container');
       this._basicPlanChangeButton = $('.basic .button.show');
       this._proPlanChangeButton = $('.pro .button.show');
+      this._basicPlanChangeButtons = element.all(by.css('.basic .button.show'));
+      this._proPlanChangeButtons = element.all(by.css('.pro .button.show'));
     }
 
     beginAuthenticatedSession() {
@@ -37,6 +39,18 @@ class MyPlanPage {
 
     isDisabledProPlanChangeButton(){
         return this._proPlanChangeButton.getAttribute('class');
+    }
+
+    isOnlyOneButtonInBasicPlanContainer(){
+        return this._basicPlanChangeButtons.count().then(function(count){
+          return count;
+        });
+    }
+
+    isOnlyOneButtonInProPlanContainer(){
+      return this._proPlanChangeButtons.count().then(function(count){
+        return count;
+      });
     }
   }
   exports.MyPlanPage = MyPlanPage;

--- a/src/spec/settings_spec.js
+++ b/src/spec/settings_spec.js
@@ -606,4 +606,38 @@ describe('Settings Page', () => {
       expect(myPlanPage.isDisabledBasicPlanChangeButton()).toMatch('button--disabled');
       expect(myPlanPage.isDisabledProPlanChangeButton()).toMatch('button--disabled');
   });
+
+  it('should show only one change plan button on each plan\'s side with require domain validation passed', () => {
+    //Arrange
+    browser.restart();
+    var emptyResponse = {
+      'data': []
+    }
+    browser.addMockModule('descartableModule2', (emptyResponse)=> angular
+      .module('descartableModule2', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/agreements\/current$/)
+        .respond(200, {
+          emptyResponse
+        });
+        $httpBackend.whenGET(/\/plans$/)
+        .respond(200, {
+          emptyResponse
+        });
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/plan$/)
+        .respond(200, {
+          emptyResponse
+        });
+      }));
+
+      //Act
+      var myPlanPage = new MyPlanPage();
+      myPlanPage.beginAuthenticatedSession();
+      browser.get('/#/settings/my-plan');
+      myPlanPage.clickChangePlanButton();
+
+      //Assert
+      expect(myPlanPage.isOnlyOneButtonInBasicPlanContainer()).toEqual(1);
+      expect(myPlanPage.isOnlyOneButtonInProPlanContainer()).toEqual(1);
+  });
 });

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -107,7 +107,7 @@
         <li class="strong">
           <h2 id="planPriceBig" class="special plan--price-big">{{vm.currency | translate}} {{vm.leftPlanPrice | number:2 | numberFormat}}</h2>
           <a ng-class="!vm.disableLeftPlan  && vm.isValidUpgradeablePlan() ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'change_plan' | translate}}</a>
-          <a ng-class="vm.disableLeftPlan ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
+          <a ng-class="vm.disableLeftPlan && vm.isValidUpgradeablePlan()? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
           <a ng-class="vm.isValidUpgradeablePlan() ? '':'show'" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
         </li>
       </ul>
@@ -145,7 +145,7 @@
           <a ng-class="!vm.disableRightPlan && !vm.showPremiumPlanBox && vm.isValidUpgradeablePlan() ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}">{{'change_plan' | translate}}</a>
           <a ng-class="!vm.disableRightPlan && vm.showPremiumPlanBox ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
           <a ng-class="vm.disableRightPlan ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
-          <a ng-class="!vm.isValidUpgradeablePlan() && !vm.showPremiumPlanBox? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
+          <a ng-class="!vm.showPremiumPlanBox && !vm.disableRightPlan? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
         </li>
       </ul>
       <div>


### PR DESCRIPTION
## Background
  
Results from test on QA
  
## Changes done
  
Some logic in the view was fixed to prevent show two buttons in the same side of plan subscription
  
## Pending to be done
  
N/A
  
## Notes
  
Add a new test to check that only must exists 1 button in each side of plan subscription containers
 
## Demo
 ISSUE:
![image](https://user-images.githubusercontent.com/7245667/38045743-1229f53c-3294-11e8-8eb6-c03f21f93fb9.png)

FIX:
![image](https://user-images.githubusercontent.com/7245667/38045774-2f2ab536-3294-11e8-9174-545c9b0c6f6c.png)

