### PR TITLE
[DR-1597] Remove Doppler relay word that it wasnt the same as spanish version

### DIFF
--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -457,7 +457,7 @@
   "dkim_configuration_help": "Domain Settings",
   "domain_name_text": "Subdomain Name",
   "tracking_domain_name_text" : "Cname Field",
-  "tracking_domain_description": "Add a CNAME value into the DNS records of your domain in order to start using your Doppler Relay account.",
+  "tracking_domain_description": "Add a CNAME value into the DNS records of your domain in order to start using your account.",
   "tracking_domain_description_link": "Learn how to do it here.",
   "tracking_config_help_href": "en/how-to-configure-the-subdomain-tracking",
   "validation_requirements_title": "Before buying a {{ companyName }} plan it is necessary to complete the following steps:",


### PR DESCRIPTION
# Overview
 HotFix to remove "Doppler Relay" word in the english version to match the spanish. And also fix the problem.