### PR TITLE
[DR-1621] Add mime fonts to prevent missing default mime types in IIS

### DIFF
--- a/src/wwwroot/styles/core/_settings.scss
+++ b/src/wwwroot/styles/core/_settings.scss
@@ -37,9 +37,9 @@ $suit-font-dir: "../fonts/";
   font-style: normal;
   font-weight: $suit-font-weight;
   src: url($suit-font-dir + 'proxima-nova.eot');
-	src: url($suit-font-dir + 'proxima-nova.eot?#iefix') format('embedded-opentype'),
-	url($suit-font-dir + 'proxima-nova.woff2') format('woff2'),
-	url($suit-font-dir + 'proxima-nova.woff') format('woff'),
+  src: url($suit-font-dir + 'proxima-nova.eot?#iefix') format('embedded-opentype'),
+  url($suit-font-dir + 'proxima-nova.woff2') format('woff2'),
+  url($suit-font-dir + 'proxima-nova.woff') format('woff'),
   url($suit-font-dir + 'proxima-nova.ttf') format('truetype'),
   url($suit-font-dir + 'proxima-nova.otf') format('opentype');
 }
@@ -49,9 +49,9 @@ $suit-font-dir: "../fonts/";
   font-style: italic;
   font-weight: $suit-font-weight;
   src: url($suit-font-dir + 'proxima-nova-italic.eot');
-	src: url($suit-font-dir + 'proxima-nova-italic.eot?#iefix') format('embedded-opentype'),
-	url($suit-font-dir + 'proxima-nova-italic.woff2') format('woff2'),
-	url($suit-font-dir + 'proxima-nova-italic.woff') format('woff'),
+  src: url($suit-font-dir + 'proxima-nova-italic.eot?#iefix') format('embedded-opentype'),
+  url($suit-font-dir + 'proxima-nova-italic.woff2') format('woff2'),
+  url($suit-font-dir + 'proxima-nova-italic.woff') format('woff'),
   url($suit-font-dir + 'proxima-nova-italic.ttf') format('truetype'),
   url($suit-font-dir + 'proxima-nova-italic.otf') format('opentype');
 }
@@ -61,9 +61,9 @@ $suit-font-dir: "../fonts/";
   font-style: normal;
   font-weight: $suit-font-weight-bold;
   src: url($suit-font-dir + 'proxima-nova-bold.eot');
-	src: url($suit-font-dir + 'proxima-nova-bold.eot?#iefix') format('embedded-opentype'),
-	url($suit-font-dir + 'proxima-nova-bold.woff2') format('woff2'),
-	url($suit-font-dir + 'proxima-nova-bold.woff') format('woff'),
+  src: url($suit-font-dir + 'proxima-nova-bold.eot?#iefix') format('embedded-opentype'),
+  url($suit-font-dir + 'proxima-nova-bold.woff2') format('woff2'),
+  url($suit-font-dir + 'proxima-nova-bold.woff') format('woff'),
   url($suit-font-dir + 'proxima-nova-bold.ttf') format('truetype'),
   url($suit-font-dir + 'proxima-nova-bold.otf') format('opentype');
 }
@@ -73,9 +73,9 @@ $suit-font-dir: "../fonts/";
   font-style: italic;
   font-weight: $suit-font-weight-bold;
   src: url($suit-font-dir + 'proxima-nova-bold-italic.eot');
-	src: url($suit-font-dir + 'proxima-nova-bold-italic.eot?#iefix') format('embedded-opentype'),
-	url($suit-font-dir + 'proxima-nova-bold-italic.woff2') format('woff2'),
-	url($suit-font-dir + 'proxima-nova-bold-italic.woff') format('woff'),
+  src: url($suit-font-dir + 'proxima-nova-bold-italic.eot?#iefix') format('embedded-opentype'),
+  url($suit-font-dir + 'proxima-nova-bold-italic.woff2') format('woff2'),
+  url($suit-font-dir + 'proxima-nova-bold-italic.woff') format('woff'),
   url($suit-font-dir + 'proxima-nova-bold-italic.ttf') format('truetype'),
   url($suit-font-dir + 'proxima-nova-bold-italic.otf') format('opentype');
 }

--- a/src/wwwroot/web.config
+++ b/src/wwwroot/web.config
@@ -4,6 +4,8 @@
             <mimeMap fileExtension=".otf" mimeType="font/opentype" />
             <mimeMap fileExtension=".woff" mimeType="font/woff" />
             <mimeMap fileExtension=".woff2" mimeType="font/woff2" />
+            <mimeMap fileExtension=".ttf" mimeType="font/ttf" />
+            <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
         </staticContent>
     </system.webServer>
 </configuration> 


### PR DESCRIPTION
## Background
  
Prevent missing default mime types on IIS servers
  
## Changes done
  
Add default mime types for ttf and eot font extensions
  
## Pending to be done
  
N/A
  
## Notes
  
RFC References: https://www.iana.org/assignments/media-types/media-types.xhtml

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
 