### PR TITLE
[DR-1621] Remove default mime types in IIS

### DIFF
--- a/src/wwwroot/web.config
+++ b/src/wwwroot/web.config
@@ -1,6 +1,8 @@
 <configuration>
     <system.webServer>
         <staticContent>
+            <remove fileExtension=".ttf" />
+            <remove fileExtension=".eot" />
             <mimeMap fileExtension=".otf" mimeType="font/opentype" />
             <mimeMap fileExtension=".woff" mimeType="font/woff" />
             <mimeMap fileExtension=".woff2" mimeType="font/woff2" />


### PR DESCRIPTION
## Background
  
Prevent missing default mime types on IIS servers
  
## Changes done

Remove default mime types to override it with new ones
Add default mime types for ttf and eot font extensions
  
## Pending to be done
  
N/A
  
## Notes
  
RFC References: https://www.iana.org/assignments/media-types/media-types.xhtml

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
 