### PR TITLE
Remove custom mime font types to prevent collitions

### DIFF
--- a/src/wwwroot/web.config
+++ b/src/wwwroot/web.config
@@ -3,6 +3,9 @@
         <staticContent>
             <remove fileExtension=".ttf" />
             <remove fileExtension=".eot" />
+            <remove fileExtension=".otf" />
+            <remove fileExtension=".woff" />
+            <remove fileExtension=".woff2" />
             <mimeMap fileExtension=".otf" mimeType="font/opentype" />
             <mimeMap fileExtension=".woff" mimeType="font/woff" />
             <mimeMap fileExtension=".woff2" mimeType="font/woff2" />


### PR DESCRIPTION
## Background
  
Possible collitions if IIS server have setted some mime font types
  
## Changes done
  
Remove custom mime types before override to prevent collitions with IIS

## Notes

Thanks @andresmoschini to alert me about this more earlier, I was wrong about the IIS behavior with overriding in mime types