### PR TITLE
[DR-1634] Hide MSEditor exit dropdown button

### DIFF
--- a/src/wwwroot/template-editor/index.html
+++ b/src/wwwroot/template-editor/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="">
   <meta name="keywords" content="" />
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="//cdn.fromdoppler.com/mseditor/v1.0.0-build349/styles/styles.min.css">
+  <link rel="stylesheet" href="//cdn.fromdoppler.com/mseditor/v1.0.0-build361/styles/styles.min.css">
 </head>
 
 <body ng-app="mseditor" class="ms-editor" ng-keydown="onKeypress($event)">
@@ -24,9 +24,10 @@
           </svg>
       </div>
     </mseditor-loader>
-  <script src="//cdn.fromdoppler.com/mseditor/v1.0.0-build349/scripts/lib.min.js"></script>
-  <script src="//cdn.fromdoppler.com/mseditor/v1.0.0-build349/scripts/app.min.js"></script>
+  <script src="//cdn.fromdoppler.com/mseditor/v1.0.0-build361/scripts/lib.min.js"></script>
+  <script src="//cdn.fromdoppler.com/mseditor/v1.0.0-build361/scripts/app.min.js"></script>
   <script src="./adapterService.js"></script>
+  <script src="./relayProvider.js"></script>
 </body>
 
 </html>

--- a/src/wwwroot/template-editor/relayProvider.js
+++ b/src/wwwroot/template-editor/relayProvider.js
@@ -1,0 +1,31 @@
+(function() {
+
+  'use strict';
+
+  // Patch to hide exit options dropdown button
+  var hideExitOptionsDropdown = false;
+
+  angular
+    .module("mseditor")
+    .provider("relay", relayProvider)
+    .config(function(relayProvider) {
+      relayProvider.$get().hideDropdown();
+    });
+
+  function relayProvider() {
+    this.$get = function() {
+      return {
+        hideDropdown: function() {
+          angular.element(document).ready(function() {
+            var mainController = document.querySelector('[ng-controller=MainCtrl]');
+            var mainScope = angular.element(mainController).scope();
+            mainScope.hideExitOptions = function() {
+              return hideExitOptionsDropdown;
+            };
+            mainScope.$apply();
+          });
+        }
+      };
+    }
+  }
+})();


### PR DESCRIPTION
## Background

We need to be able to hide exit options dropdown in Relay
  
## Changes done
  
Add a custom provider to inject dinamically the method to hide the element
  
## Pending to be done
  
Update cdn build version targeting a MSEditor develop branch build.

## Notes

This is a patch to hide the dropdown, depends on a "ng-hide" directive in the MSEditor dropdown element listening for the implementation to hide the button.
Related pr: https://github.com/MakingSense/MSEditor/pull/1262

## Demo
 
![image](https://user-images.githubusercontent.com/7245667/40680220-b8b6414c-635b-11e8-9e38-03b9f163e3bc.png)

![image](https://user-images.githubusercontent.com/7245667/40680236-ca700184-635b-11e8-890d-b68ae7d265ac.png)
