### PR TITLE
chore: add docker image delivery for INT environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
                     branch 'main'
                     branch 'develop'
                     branch 'qa'
+                    branch 'INT'
                     buildingTag()
                 }
             }            


### PR DESCRIPTION
Add missing _int_ branch for generating and delivery docker images for _integration environment_

Related to: [DD-577](https://makingsense.atlassian.net/browse/DD-577)