### PR TITLE
chore(ci): add workaround for bower cert expired error

### DIFF
--- a/src/.bowerrc
+++ b/src/.bowerrc
@@ -1,3 +1,5 @@
 {
+  "strict-ssl": false,
+  "https-proxy": "",
   "directory": "wwwroot/lib"
 }


### PR DESCRIPTION
See:
- https://stackoverflow.com/questions/76089161/how-to-refresh-bower-package-certificate
- https://github.com/bower/bower/issues/2608